### PR TITLE
Add basic unit tests for BoardForge

### DIFF
--- a/tests/test_boardforge.py
+++ b/tests/test_boardforge.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+import zipfile
+import pytest
+
+# Add the boardforge project v46 directory to sys.path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "boardforge_project_v46"))
+
+from boardforge import Pin, Component, Board, TOP_SILK, BOTTOM_SILK
+
+
+def test_pin_rotation():
+    pin = Pin("A", (10, 20), 1, 0, rotation=90)
+    assert pytest.approx(pin.x, rel=1e-6) == 10
+    assert pytest.approx(pin.y, rel=1e-6) == 21
+
+
+def test_pad_rotation():
+    comp = Component("R1", "RES", at=(0, 0), rotation=90)
+    pad = comp.add_pad("P1", 1, 0, w=1, h=1)
+    assert pytest.approx(pad.x, rel=1e-6) == 0
+    assert pytest.approx(pad.y, rel=1e-6) == 1
+
+
+def test_export_creates_zip_and_files(tmp_path):
+    board = Board(width=10, height=10)
+    board.set_layer_stack(["GTL", "GBL", TOP_SILK, BOTTOM_SILK])
+    comp = board.add_component("TEST", ref="C1", at=(2, 2))
+    comp.add_pin("A", dx=0, dy=0)
+    comp.add_pin("B", dx=1, dy=0)
+    board.trace(comp.pin("A"), comp.pin("B"))
+
+    zip_path = tmp_path / "out.zip"
+    board.export_gerbers(zip_path)
+
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as z:
+        names = set(z.namelist())
+
+    assert "GTL.gbr" in names
+    assert "GTO.gbr" in names
+    assert "preview_top.svg" in names


### PR DESCRIPTION
## Summary
- add tests covering Pin rotation logic, pad placement, and Gerber export

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877fee4bbac8329bb842a49aacb25e9