### PR TITLE
Remove redundant log function

### DIFF
--- a/boardforge_project_v46/boardforge/Board.py
+++ b/boardforge_project_v46/boardforge/Board.py
@@ -11,11 +11,6 @@ TOP_SILK = "GTO"
 BOTTOM_SILK = "GBO"
 
 import datetime
-def log(msg):
-    with open('boardforge.log', 'a', encoding='utf-8') as f:
-        f.write(f"{datetime.datetime.now().isoformat()} {msg}\n")
-
-import datetime
 import pprint
 def log(msg, obj=None):
     with open('boardforge.log', 'a', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary
- clean up Board logging function in boardforge

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68780b64b9948329bab096e8b0398d51