### PR TITLE
Add PNG conversion for Gerber previews

### DIFF
--- a/boardforge_project_v46/boardforge/Board.py
+++ b/boardforge_project_v46/boardforge/Board.py
@@ -170,6 +170,17 @@ class Board:
             try:
                 with open(output_path, "w", encoding="utf-8") as f:
                     f.write('\n'.join(svg_content))
+                # Convert the SVG preview to PNG for easier visual inspection
+                try:
+                    from cairosvg import svg2png
+                    png_path = os.path.join(outdir, f"preview_{suffix}.png")
+                    svg2png(bytes('\n'.join(svg_content), 'utf-8'), write_to=png_path)
+                    # Simple verification: ensure the file was written and is not empty
+                    if os.path.getsize(png_path) == 0:
+                        os.remove(png_path)
+                        raise ValueError("Generated PNG is empty")
+                except Exception as e:
+                    print(f"Error converting SVG to PNG: {e}")
             except Exception as e:
                 print(f"Error writing SVG preview to {output_path}: {e}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ svg.path
 fonttools
 pytest
 pytest-timeout
+cairosvg

--- a/tests/test_boardforge.py
+++ b/tests/test_boardforge.py
@@ -37,10 +37,13 @@ def test_export_creates_zip_and_files(tmp_path):
     assert zip_path.exists()
     with zipfile.ZipFile(zip_path) as z:
         names = set(z.namelist())
+        top_png = z.read("preview_top.png") if "preview_top.png" in names else b""
 
     assert "GTL.gbr" in names
     assert "GTO.gbr" in names
     assert "preview_top.svg" in names
+    assert "preview_top.png" in names
+    assert len(top_png) > 0
 
 
 def test_sample_circuit_gerber_contains_trace(tmp_path):


### PR DESCRIPTION
## Summary
- convert preview SVGs to PNG when exporting Gerbers
- require `cairosvg` for PNG generation
- test for PNG output

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780fb004b883298164824494b0724d