### PR TITLE
Add common circuit helpers and tests

### DIFF
--- a/boardforge_project_v46/README.md
+++ b/boardforge_project_v46/README.md
@@ -86,6 +86,22 @@ board.add_text_ttf("Torch-O-Matic 3000", font_path="fonts/RobotoMono.ttf", at=(5
 board.export_gerbers("output/boardforge_output.zip")
 ```
 
+## 🪫 Common Circuits
+
+The package also provides helpers to create a few everyday circuits:
+
+```python
+from boardforge import (
+    create_voltage_divider,
+    create_led_indicator,
+    create_rc_lowpass,
+)
+
+divider = create_voltage_divider()
+indicator = create_led_indicator()
+lowpass = create_rc_lowpass()
+```
+
 ## 🧰 API Reference
 
 ### `Board`

--- a/boardforge_project_v46/boardforge/__init__.py
+++ b/boardforge_project_v46/boardforge/__init__.py
@@ -4,6 +4,11 @@ from .Component import Component
 from .Via import Via
 from .Graphic import Graphic
 from .Board import Board
+from .circuits import (
+    create_voltage_divider,
+    create_led_indicator,
+    create_rc_lowpass,
+)
 
 # Default symbolic layer names
 TOP_SILK = "GTO"

--- a/boardforge_project_v46/boardforge/circuits.py
+++ b/boardforge_project_v46/boardforge/circuits.py
@@ -1,0 +1,101 @@
+from .Board import Board, TOP_SILK, BOTTOM_SILK
+
+
+def create_voltage_divider():
+    """Return a board with a simple voltage divider (two resistors)."""
+    board = Board(width=5, height=5)
+    board.set_layer_stack(["GTL", "GBL", TOP_SILK, BOTTOM_SILK])
+
+    vin = board.add_component("VIN", ref="J1", at=(0.5, 2.5))
+    vin.add_pin("VCC", dx=0, dy=0)
+    vin.add_pin("GND", dx=0, dy=-1)
+    vin.add_pad("VCC", dx=0, dy=0, w=1, h=1)
+    vin.add_pad("GND", dx=0, dy=-1, w=1, h=1)
+
+    r1 = board.add_component("RES", ref="R1", at=(2.0, 2.5))
+    r1.add_pin("A", dx=-0.5, dy=0)
+    r1.add_pin("B", dx=0.5, dy=0)
+    r1.add_pad("A", dx=-0.5, dy=0, w=1, h=1)
+    r1.add_pad("B", dx=0.5, dy=0, w=1, h=1)
+
+    r2 = board.add_component("RES", ref="R2", at=(3.5, 2.5))
+    r2.add_pin("A", dx=-0.5, dy=0)
+    r2.add_pin("B", dx=0.5, dy=0)
+    r2.add_pad("A", dx=-0.5, dy=0, w=1, h=1)
+    r2.add_pad("B", dx=0.5, dy=0, w=1, h=1)
+
+    vout = board.add_component("VOUT", ref="J2", at=(4.5, 2.5))
+    vout.add_pin("OUT", dx=0, dy=0)
+    vout.add_pad("OUT", dx=0, dy=0, w=1, h=1)
+
+    board.trace(vin.pin("VCC"), r1.pin("A"))
+    board.trace(r1.pin("B"), r2.pin("A"))
+    board.trace(r2.pin("B"), vout.pin("OUT"))
+    board.trace(r2.pin("B"), vin.pin("GND"))
+
+    return board
+
+
+def create_led_indicator():
+    """Return a board with a battery, resistor and LED."""
+    board = Board(width=5, height=5)
+    board.set_layer_stack(["GTL", "GBL", TOP_SILK, BOTTOM_SILK])
+
+    bat = board.add_component("BAT", ref="BT1", at=(0.5, 2))
+    bat.add_pin("VCC", dx=0, dy=0)
+    bat.add_pin("GND", dx=0, dy=-1)
+    bat.add_pad("VCC", dx=0, dy=0, w=1, h=1)
+    bat.add_pad("GND", dx=0, dy=-1, w=1, h=1)
+
+    r = board.add_component("RES", ref="R1", at=(2.0, 2))
+    r.add_pin("A", dx=-0.5, dy=0)
+    r.add_pin("B", dx=0.5, dy=0)
+    r.add_pad("A", dx=-0.5, dy=0, w=1, h=1)
+    r.add_pad("B", dx=0.5, dy=0, w=1, h=1)
+
+    led = board.add_component("LED", ref="D1", at=(3.5, 2))
+    led.add_pin("A", dx=-0.5, dy=0)
+    led.add_pin("K", dx=0.5, dy=0)
+    led.add_pad("A", dx=-0.5, dy=0, w=1, h=1)
+    led.add_pad("K", dx=0.5, dy=0, w=1, h=1)
+
+    board.trace(bat.pin("VCC"), r.pin("A"))
+    board.trace(r.pin("B"), led.pin("A"))
+    board.trace(led.pin("K"), bat.pin("GND"))
+
+    return board
+
+
+def create_rc_lowpass():
+    """Return a board with a resistor and capacitor configured as a low-pass filter."""
+    board = Board(width=5, height=5)
+    board.set_layer_stack(["GTL", "GBL", TOP_SILK, BOTTOM_SILK])
+
+    j1 = board.add_component("IN", ref="J1", at=(0.5, 2.5))
+    j1.add_pin("VIN", dx=0, dy=0)
+    j1.add_pin("GND", dx=0, dy=-1)
+    j1.add_pad("VIN", dx=0, dy=0, w=1, h=1)
+    j1.add_pad("GND", dx=0, dy=-1, w=1, h=1)
+
+    r = board.add_component("RES", ref="R1", at=(2.0, 2.5))
+    r.add_pin("A", dx=-0.5, dy=0)
+    r.add_pin("B", dx=0.5, dy=0)
+    r.add_pad("A", dx=-0.5, dy=0, w=1, h=1)
+    r.add_pad("B", dx=0.5, dy=0, w=1, h=1)
+
+    c = board.add_component("CAP", ref="C1", at=(3.5, 2.5))
+    c.add_pin("A", dx=0, dy=0)
+    c.add_pin("B", dx=0, dy=-1)
+    c.add_pad("A", dx=0, dy=0, w=1, h=1)
+    c.add_pad("B", dx=0, dy=-1, w=1, h=1)
+
+    j2 = board.add_component("OUT", ref="J2", at=(4.5, 2.5))
+    j2.add_pin("VOUT", dx=0, dy=0)
+    j2.add_pad("VOUT", dx=0, dy=0, w=1, h=1)
+
+    board.trace(j1.pin("VIN"), r.pin("A"))
+    board.trace(r.pin("B"), j2.pin("VOUT"))
+    board.trace(r.pin("B"), c.pin("A"))
+    board.trace(c.pin("B"), j1.pin("GND"))
+
+    return board

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+import zipfile
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "boardforge_project_v46"))
+
+from boardforge import (
+    create_voltage_divider,
+    create_led_indicator,
+    create_rc_lowpass,
+)
+
+
+def check_zip_created(board, tmp_path):
+    zip_path = tmp_path / "out.zip"
+    board.export_gerbers(zip_path)
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as z:
+        assert {"GTL.gbr", "GBL.gbr", "GTO.gbr", "GBO.gbr"}.issubset(set(z.namelist()))
+
+
+def test_voltage_divider(tmp_path):
+    board = create_voltage_divider()
+    assert len(board.components) == 4
+    assert len(board.layers["GTL"]) == 4
+    check_zip_created(board, tmp_path)
+
+
+def test_led_indicator(tmp_path):
+    board = create_led_indicator()
+    assert len(board.components) == 3
+    assert len(board.layers["GTL"]) == 3
+    check_zip_created(board, tmp_path)
+
+
+def test_rc_lowpass(tmp_path):
+    board = create_rc_lowpass()
+    assert len(board.components) == 4
+    assert len(board.layers["GTL"]) == 4
+    check_zip_created(board, tmp_path)
+
+


### PR DESCRIPTION
## Summary
- add helper functions for common circuits
- expose helpers from boardforge
- document helper usage in README
- test each circuit builder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687829271d348329ad17a00254600080