### PR TITLE
Add microcontroller board example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains several versions of the **BoardForge** project, a Pytho
 │   ├── boardforge/                    # Python package with PCB classes
 │   ├── fonts/                         # Font files used for text rendering
 │   ├── graphics/                      # Example SVG assets
+│   ├── examples/                      # Additional usage demos
 │   └── output/                        # Generated Gerber previews
 ├── boardforge_project_v46_grokmod.zip # Zipped copy of v46 project
 ├── boardforge_project_v5/             # Previous revision (v5)
@@ -23,6 +24,9 @@ This repository contains several versions of the **BoardForge** project, a Pytho
 ```
 
 Log files such as `boardforge.log` may appear when running the demos.
+
+Example scripts in the `examples/` folder demonstrate advanced usage such as
+the `arduino_like.py` microcontroller board.
 
 ## Running the tests
 

--- a/boardforge_project_v46/README.md
+++ b/boardforge_project_v46/README.md
@@ -99,8 +99,15 @@ from boardforge import (
 
 divider = create_voltage_divider()
 indicator = create_led_indicator()
+
 lowpass = create_rc_lowpass()
 ```
+
+## 📚 Additional Example
+
+An Arduino-like microcontroller board is provided under `examples/arduino_like.py`.
+Run the script to generate `output/arduino_like.zip` and preview images. See
+`examples/README.md` for the pinout and component overview.
 
 ## 🧰 API Reference
 

--- a/boardforge_project_v46/examples/README.md
+++ b/boardforge_project_v46/examples/README.md
@@ -1,0 +1,54 @@
+# Arduino-like MCU Board Example
+
+This example shows how to use **BoardForge** to create a small microcontroller board.  The board hosts a 28‑pin MCU and breaks out the pins to two headers similar to a traditional Arduino layout.
+
+Run the example:
+
+```bash
+python arduino_like.py
+```
+
+Gerber files and SVG previews will be written to `boardforge_project_v46/output/arduino_like.zip` and the corresponding preview PNG/SVG files.
+
+## MCU Pinout
+
+### Left side (top to bottom)
+1. D0
+2. D1
+3. D2
+4. D3
+5. D4
+6. D5
+7. D6
+8. D7
+9. VCC
+10. GND
+11. RST
+12. VIN
+13. 3V3
+14. AREF
+
+### Right side (top to bottom)
+1. D8
+2. D9
+3. D10
+4. D11
+5. D12
+6. D13
+7. A0
+8. A1
+9. A2
+10. A3
+11. A4
+12. A5
+13. VCC
+14. GND
+
+## Components
+- **U1** – 28‑pin microcontroller
+- **J1** – 14‑pin digital I/O header
+- **J2** – 6‑pin analog header
+- **J3** – Power header (VIN, VCC, 3V3, GND)
+- **J4** – 6‑pin programming header
+
+The example script connects each MCU pin to the corresponding header pad and adds simple silkscreen labels.  Use it as a starting point for your own custom microcontroller boards.

--- a/boardforge_project_v46/examples/arduino_like.py
+++ b/boardforge_project_v46/examples/arduino_like.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+from boardforge import Board, TOP_SILK, BOTTOM_SILK
+
+
+BASE_DIR = Path(__file__).resolve().parent
+FONT_PATH = BASE_DIR.parent / "fonts" / "RobotoMono.ttf"
+OUTPUT_DIR = BASE_DIR.parent / "output"
+
+
+def build_board():
+    board = Board(width=70, height=55)
+    board.set_layer_stack(["GTL", "GBL", TOP_SILK, BOTTOM_SILK])
+
+    # 28-pin MCU in the center
+    mcu = board.add_component("MCU", ref="U1", at=(35, 27))
+
+    left_pins = [
+        "D0", "D1", "D2", "D3", "D4", "D5", "D6", "D7",
+        "VCC", "GND", "RST", "VIN", "3V3", "AREF",
+    ]
+    right_pins = [
+        "D8", "D9", "D10", "D11", "D12", "D13",
+        "A0", "A1", "A2", "A3", "A4", "A5", "VCC", "GND",
+    ]
+    mcu_pins = set(left_pins + right_pins)
+
+    for i, name in enumerate(left_pins):
+        dy = -13 + i * 2
+        mcu.add_pin(name, dx=-5, dy=dy)
+        mcu.add_pad(name, dx=-5, dy=dy, w=1.2, h=1.2)
+    for i, name in enumerate(right_pins):
+        dy = -13 + i * 2
+        mcu.add_pin(name, dx=5, dy=dy)
+        mcu.add_pad(name, dx=5, dy=dy, w=1.2, h=1.2)
+
+    # Digital header along left edge
+    header_d = board.add_component("HEADER", ref="J1", at=(5, 27))
+    for i, name in enumerate(["D0", "D1", "D2", "D3", "D4", "D5", "D6", "D7", "D8", "D9", "D10", "D11", "D12", "D13"]):
+        dy = -13 + i * 2
+        header_d.add_pin(name, dx=0, dy=dy)
+        header_d.add_pad(name, dx=0, dy=dy, w=1.2, h=1.2)
+        board.trace(mcu.pin(name), header_d.pin(name))
+
+    # Analog header along right edge
+    header_a = board.add_component("HEADER", ref="J2", at=(65, 23))
+    analog_pins = ["A0", "A1", "A2", "A3", "A4", "A5"]
+    for i, name in enumerate(analog_pins):
+        dy = -5 + i * 2
+        header_a.add_pin(name, dx=0, dy=dy)
+        header_a.add_pad(name, dx=0, dy=dy, w=1.2, h=1.2)
+        board.trace(mcu.pin(name), header_a.pin(name))
+
+    # Power header
+    pwr = board.add_component("POWER", ref="J3", at=(35, 50))
+    power_pins = ["VIN", "VCC", "3V3", "GND"]
+    for i, name in enumerate(power_pins):
+        dx = -6 + i * 4
+        pwr.add_pin(name, dx=dx, dy=0)
+        pwr.add_pad(name, dx=dx, dy=0, w=1.2, h=1.2)
+        if name in mcu_pins:
+            board.trace(mcu.pin(name), pwr.pin(name))
+
+    # Programming header (2x3)
+    prog = board.add_component("PROG", ref="J4", at=(35, 10))
+    prog_map = [
+        ("MISO", "D12", -4),
+        ("SCK", "D13", -2),
+        ("RST", "RST", 0),
+        ("MOSI", "D11", 2),
+        ("VCC", "VCC", 4),
+        ("GND", "GND", 6),
+    ]
+    for name, mcu_pin, dx in prog_map:
+        prog.add_pin(name, dx=dx, dy=0)
+        prog.add_pad(name, dx=dx, dy=0, w=1.2, h=1.2)
+        board.trace(mcu.pin(mcu_pin), prog.pin(name))
+
+    # Label components
+    for comp in [mcu, header_d, header_a, pwr, prog]:
+        board.add_text_ttf(comp.ref, font_path=str(FONT_PATH), at=(comp.at[0]-4, comp.at[1]-5), size=1.1, layer=TOP_SILK)
+
+    return board
+
+
+def main():
+    board = build_board()
+    board.save_svg_previews(str(OUTPUT_DIR))
+    board.export_gerbers(str(OUTPUT_DIR / "arduino_like.zip"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mcu_example.py
+++ b/tests/test_mcu_example.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+import zipfile
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "boardforge_project_v46"))
+
+from examples import arduino_like
+
+
+def test_arduino_like_board(tmp_path):
+    board = arduino_like.build_board()
+    zip_path = tmp_path / "mcu.zip"
+    board.export_gerbers(zip_path)
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as z:
+        names = set(z.namelist())
+        assert {"GTL.gbr", "GBL.gbr", "GTO.gbr", "GBO.gbr"}.issubset(names)
+


### PR DESCRIPTION
## Summary
- add example folder to README
- document arduino-like MCU board example
- implement `arduino_like.py` to generate an MCU breakout
- reference the example in boardforge README
- add test for arduino-like board

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68782b7c82b08329b54991b91262c03b