### PR TITLE
Parameterize bent trace path

### DIFF
--- a/boardforge_project_v46/boardforge/circuits.py
+++ b/boardforge_project_v46/boardforge/circuits.py
@@ -101,8 +101,15 @@ def create_rc_lowpass():
     return board
 
 
-def create_bent_trace():
-    """Return a board demonstrating a trace with a 90-degree bend."""
+def create_bent_trace(path=None):
+    """Return a board demonstrating a trace with a bend.
+
+    Parameters
+    ----------
+    path : list, optional
+        Sequence of coordinates or Pin objects representing the trace path.
+        If omitted, a default 90-degree bend is used.
+    """
     board = Board(width=5, height=5)
     board.set_layer_stack(["GTL", "GBL", TOP_SILK, BOTTOM_SILK])
 
@@ -114,7 +121,8 @@ def create_bent_trace():
     j2.add_pin("SIG", dx=0, dy=0)
     j2.add_pad("SIG", dx=0, dy=0, w=1, h=1)
 
-    path = [j1.pin("SIG"), (2.5, 4.0), j2.pin("SIG")]
+    if path is None:
+        path = [j1.pin("SIG"), (2.5, 4.0), j2.pin("SIG")]
     board.trace_path(path)
 
     return board

--- a/boardforge_project_v46/examples/bent_trace.py
+++ b/boardforge_project_v46/examples/bent_trace.py
@@ -6,7 +6,12 @@ OUTPUT_DIR = BASE_DIR.parent / "output"
 
 
 def main():
+    # Use the default 90-degree path.  Pass a list of points to ``path`` to
+    # customise the route.
     board = create_bent_trace()
+    # Example customisation:
+    # board = create_bent_trace(path=[(0.5, 2.5), (2.5, 4.5), (4.5, 2.5)])
+
     board.save_svg_previews(str(OUTPUT_DIR))
     board.export_gerbers(str(OUTPUT_DIR / "bent_trace.zip"))
 


### PR DESCRIPTION
## Summary
- allow providing custom path to `create_bent_trace`
- show optional usage in `examples/bent_trace.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878391284dc8329b777cf09a54b854e