### PR TITLE
Add exploded Gerber folder output

### DIFF
--- a/README_V46.md
+++ b/README_V46.md
@@ -84,6 +84,8 @@ board.add_svg_graphic(svg_path, layer=BOTTOM_SILK, scale=1.0, at=(10, 10))
 board.add_text_ttf("Torch-O-Matic 3000", font_path="fonts/RobotoMono.ttf", at=(5, 50), size=1.5, layer=TOP_SILK)
 
 board.export_gerbers("output/boardforge_output.zip")
+# Creates 'boardforge_output.zip' and an exploded
+# folder 'boardforge_output' with the same files
 ```
 
 ## 🪫 Common Circuits

--- a/boardforge/GerberExporter.py
+++ b/boardforge/GerberExporter.py
@@ -53,12 +53,15 @@ def export_gerbers(board, output_zip_path):
         if hasattr(board, 'save_svg_previews'):
             board.save_svg_previews(str(temp_dir))
         
-        # Create ZIP archive
+        # Prepare exploded output directory and ZIP archive
+        exploded_dir = output_zip_path.parent / output_zip_path.stem
+        exploded_dir.mkdir(parents=True, exist_ok=True)
+
         with zipfile.ZipFile(output_zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
             for file_path in temp_dir.glob("*"):
                 if file_path.is_file():
-                    # Use relative path in ZIP to avoid including full directory structure
                     zipf.write(file_path, file_path.name)
+                    shutil.copy(file_path, exploded_dir / file_path.name)
     
     except Exception as e:
         print(f"Error during Gerber export: {str(e)}")

--- a/tests/test_boardforge.py
+++ b/tests/test_boardforge.py
@@ -71,6 +71,11 @@ def test_export_creates_zip_and_files(tmp_path):
     assert gto_data == expected_gto
     assert gbo_data == expected_gbo
 
+    exploded_dir = tmp_path / "out"
+    assert exploded_dir.exists()
+    assert (exploded_dir / "GTL.gbr").read_text() == expected_gtl
+    assert (exploded_dir / "preview_top.svg").exists()
+
 
 def test_sample_circuit_gerber_contains_trace(tmp_path):
     board = Board(width=5, height=5)


### PR DESCRIPTION
## Summary
- keep generated Gerber files in an exploded folder alongside the ZIP
- mention new behaviour in README_V46
- test that the exploded folder is created with previews

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687842e6bd808329a91f51d8564a82b7