### PR TITLE
Refactor tests/examples for new API

### DIFF
--- a/examples/arduino_like.py
+++ b/examples/arduino_like.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from boardforge import Board, TOP_SILK, BOTTOM_SILK
+from boardforge import PCB, Layer
 
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -8,8 +8,13 @@ OUTPUT_DIR = BASE_DIR.parent / "output"
 
 
 def build_board():
-    board = Board(width=70, height=55)
-    board.set_layer_stack(["GTL", "GBL", TOP_SILK, BOTTOM_SILK])
+    board = PCB(width=70, height=55)
+    board.set_layer_stack([
+        Layer.TOP_COPPER.value,
+        Layer.BOTTOM_COPPER.value,
+        Layer.TOP_SILK.value,
+        Layer.BOTTOM_SILK.value,
+    ])
 
     # 28-pin MCU in the center
     mcu = board.add_component("MCU", ref="U1", at=(35, 27))
@@ -39,7 +44,7 @@ def build_board():
         dy = -13 + i * 2
         header_d.add_pin(name, dx=0, dy=dy)
         header_d.add_pad(name, dx=0, dy=dy, w=1.2, h=1.2)
-        board.trace(mcu.pin(name), header_d.pin(name))
+        board.route_trace(f"U1:{name}", f"J1:{name}")
 
     # Analog header along right edge
     header_a = board.add_component("HEADER", ref="J2", at=(65, 23))
@@ -48,7 +53,7 @@ def build_board():
         dy = -5 + i * 2
         header_a.add_pin(name, dx=0, dy=dy)
         header_a.add_pad(name, dx=0, dy=dy, w=1.2, h=1.2)
-        board.trace(mcu.pin(name), header_a.pin(name))
+        board.route_trace(f"U1:{name}", f"J2:{name}")
 
     # Power header
     pwr = board.add_component("POWER", ref="J3", at=(35, 50))
@@ -58,7 +63,7 @@ def build_board():
         pwr.add_pin(name, dx=dx, dy=0)
         pwr.add_pad(name, dx=dx, dy=0, w=1.2, h=1.2)
         if name in mcu_pins:
-            board.trace(mcu.pin(name), pwr.pin(name))
+            board.route_trace(f"U1:{name}", f"J3:{name}")
 
     # Programming header (2x3)
     prog = board.add_component("PROG", ref="J4", at=(35, 10))
@@ -73,11 +78,11 @@ def build_board():
     for name, mcu_pin, dx in prog_map:
         prog.add_pin(name, dx=dx, dy=0)
         prog.add_pad(name, dx=dx, dy=0, w=1.2, h=1.2)
-        board.trace(mcu.pin(mcu_pin), prog.pin(name))
+        board.route_trace(f"U1:{mcu_pin}", f"J4:{name}")
 
     # Label components
     for comp in [mcu, header_d, header_a, pwr, prog]:
-        board.add_text_ttf(comp.ref, font_path=str(FONT_PATH), at=(comp.at[0]-4, comp.at[1]-5), size=1.1, layer=TOP_SILK)
+        board.add_text_ttf(comp.ref, font_path=str(FONT_PATH), at=(comp.at[0]-4, comp.at[1]-5), size=1.1, layer=Layer.TOP_SILK.value)
 
     return board
 

--- a/examples/esp32_dev_board.py
+++ b/examples/esp32_dev_board.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from boardforge import Board, TOP_SILK, BOTTOM_SILK
+from boardforge import PCB, Layer
 
 BASE_DIR = Path(__file__).resolve().parent
 FONT_PATH = BASE_DIR.parent / "fonts" / "RobotoMono.ttf"
@@ -7,8 +7,13 @@ OUTPUT_DIR = BASE_DIR.parent / "output"
 
 
 def build_board():
-    board = Board(width=60, height=35)
-    board.set_layer_stack(["GTL", "GBL", TOP_SILK, BOTTOM_SILK])
+    board = PCB(width=60, height=35)
+    board.set_layer_stack([
+        Layer.TOP_COPPER.value,
+        Layer.BOTTOM_COPPER.value,
+        Layer.TOP_SILK.value,
+        Layer.BOTTOM_SILK.value,
+    ])
 
     # Mounting holes
     holes = [(3, 3), (57, 3), (3, 32), (57, 32)]
@@ -136,13 +141,13 @@ def build_board():
     ])
 
     # GND traces
-    board.trace(boot.pin("2"), esp32.pin("GND"))
-    board.trace(reset.pin("2"), esp32.pin("GND"))
-    board.trace(ldo.pin("GND"), esp32.pin("GND"))
-    board.trace(ch340.pin("GND"), esp32.pin("GND"))
+    board.route_trace("SW_BOOT:2", "U1:GND")
+    board.route_trace("SW_RESET:2", "U1:GND")
+    board.route_trace("U3:GND", "U1:GND")
+    board.route_trace("U2:GND", "U1:GND")
 
-    board.add_text_ttf("ESP32 Dev Board", font_path=str(FONT_PATH), at=(5, 32), size=1.2, layer=TOP_SILK)
-    board.add_text_ttf("USB-C", font_path=str(FONT_PATH), at=(28, 2), size=1.0, layer=TOP_SILK)
+    board.add_text_ttf("ESP32 Dev Board", font_path=str(FONT_PATH), at=(5, 32), size=1.2, layer=Layer.TOP_SILK.value)
+    board.add_text_ttf("USB-C", font_path=str(FONT_PATH), at=(28, 2), size=1.0, layer=Layer.TOP_SILK.value)
 
     return board
 

--- a/tests/test_boardforge.py
+++ b/tests/test_boardforge.py
@@ -9,7 +9,7 @@ EXPECTED_DIR = Path(__file__).resolve().parent / "expected"
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from boardforge import Pin, Component, Board, TOP_SILK, BOTTOM_SILK
+from boardforge import Pin, Component, PCB, Layer
 
 
 def test_pin_rotation():
@@ -26,12 +26,21 @@ def test_pad_rotation():
 
 
 def test_export_creates_zip_and_files(tmp_path):
-    board = Board(width=10, height=10)
-    board.set_layer_stack(["GTL", "GBL", TOP_SILK, BOTTOM_SILK])
+    board = PCB(width=10, height=10)
+    board.set_layer_stack([
+        Layer.TOP_COPPER.value,
+        Layer.BOTTOM_COPPER.value,
+        Layer.TOP_SILK.value,
+        Layer.BOTTOM_SILK.value,
+    ])
     comp = board.add_component("TEST", ref="C1", at=(2, 2))
     comp.add_pin("A", dx=0, dy=0)
     comp.add_pin("B", dx=1, dy=0)
-    board.trace(comp.pin("A"), comp.pin("B"))
+    board.route_trace("C1:A", "C1:B", layer=Layer.TOP_COPPER.value)
+    via = board.add_via(5, 5, from_layer=Layer.TOP_COPPER.value, to_layer=Layer.BOTTOM_COPPER.value)
+    zone = board.add_filled_zone(net="GND", layer=Layer.BOTTOM_COPPER.value)
+    assert via in board.vias
+    assert zone in board.zones
 
     zip_path = tmp_path / "out.zip"
     board.export_gerbers(zip_path)
@@ -78,8 +87,13 @@ def test_export_creates_zip_and_files(tmp_path):
 
 
 def test_sample_circuit_gerber_contains_trace(tmp_path):
-    board = Board(width=5, height=5)
-    board.set_layer_stack(["GTL", "GBL", TOP_SILK, BOTTOM_SILK])
+    board = PCB(width=5, height=5)
+    board.set_layer_stack([
+        Layer.TOP_COPPER.value,
+        Layer.BOTTOM_COPPER.value,
+        Layer.TOP_SILK.value,
+        Layer.BOTTOM_SILK.value,
+    ])
 
     r1 = board.add_component("RES", ref="R1", at=(1, 1))
     r1.add_pin("A", dx=-0.5, dy=0)
@@ -93,7 +107,7 @@ def test_sample_circuit_gerber_contains_trace(tmp_path):
     r2.add_pad("A", dx=-0.5, dy=0, w=1, h=1)
     r2.add_pad("B", dx=0.5, dy=0, w=1, h=1)
 
-    board.trace(r1.pin("B"), r2.pin("A"))
+    board.route_trace("R1:B", "R2:A")
 
     zip_path = tmp_path / "circuit.zip"
     board.export_gerbers(zip_path)

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -9,6 +9,7 @@ from boardforge import (
     create_voltage_divider,
     create_led_indicator,
     create_rc_lowpass,
+    Layer,
 )
 
 
@@ -23,21 +24,21 @@ def check_zip_created(board, tmp_path):
 def test_voltage_divider(tmp_path):
     board = create_voltage_divider()
     assert len(board.components) == 4
-    assert len(board.layers["GTL"]) == 4
+    assert len(board.layers[Layer.TOP_COPPER.value]) == 4
     check_zip_created(board, tmp_path)
 
 
 def test_led_indicator(tmp_path):
     board = create_led_indicator()
     assert len(board.components) == 3
-    assert len(board.layers["GTL"]) == 3
+    assert len(board.layers[Layer.TOP_COPPER.value]) == 3
     check_zip_created(board, tmp_path)
 
 
 def test_rc_lowpass(tmp_path):
     board = create_rc_lowpass()
     assert len(board.components) == 4
-    assert len(board.layers["GTL"]) == 4
+    assert len(board.layers[Layer.TOP_COPPER.value]) == 4
     check_zip_created(board, tmp_path)
 
 


### PR DESCRIPTION
## Summary
- update tests to use `PCB`, `Layer` enum, `route_trace`, vias and zones
- adjust examples to use the new public interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878b73fc8708329b5f37cd95b45c720