### PR TITLE
Add layer service design rule constants

### DIFF
--- a/boardforge/__init__.py
+++ b/boardforge/__init__.py
@@ -39,6 +39,56 @@ class Footprint(Enum):
     HEADER_1x5 = "HEADER_1x5"
 
 
+# Basic design rule parameters for common board configurations
+LAYER_SERVICE_RULES = {
+    "2 Layer Services": {
+        "Minimum Clearance": "6mil (0.1524mm)",
+        "Minimum track Width": "6mil (0.1524mm)",
+        "Minimum Connection Width": "6mil (0.1524mm)",
+        "Minimum Annular Ring": "5mil (0.127mm)",
+        "Minimum Via Diameter": "20mil (0.508mm)",
+        "Copper to hole clearance": "5mil (0.127mm)",
+        "Minimum Through Hole": "10mil (0.254mm)",
+        "Hole to hole clearance": "5mil (0.127mm)",
+        "Minimum uVia diameter": "20mil (0.508mm)",
+        "minimum uVia Hole": "10mil (0.254mm)",
+        "Silkscreen Min Item Clearance": "user preference",
+        "Silkscreen Min Text Height": "user preference",
+        "Silkscreen Min Text Thickness": "5mil (0.127mm)",
+    },
+    "4 Layer": {
+        "Minimum Clearance": "5mil (0.127mm)",
+        "Minimum track Width": "5mil (0.127mm)",
+        "Minimum Connection Width": "5mil (0.127mm)",
+        "Minimum Annular Ring": "4mil (0.1016mm)",
+        "Minimum Via Diameter": "18mil (0.4572mm)",
+        "Copper to hole clearance": "5mil (0.127mm)",
+        "Minimum Through Hole": "10mil (0.254mm)",
+        "Hole to hole clearance": "5mil (0.127mm)",
+        "Minimum uVia diameter": "18mil (0.4572mm)",
+        "minimum uVia Hole": "10mil (0.254mm)",
+        "Silkscreen Min Item Clearance": "any",
+        "Silkscreen Min Text Height": "any",
+        "Silkscreen Min Text Thickness": "5mil (0.127mm)",
+    },
+    "6 Layer": {
+        "Minimum Clearance": "5mil (0.127mm)",
+        "Minimum track Width": "5mil (0.127mm)",
+        "Minimum Connection Width": "5mil (0.127mm)",
+        "Minimum Annular Ring": "4mil (0.1016mm)",
+        "Minimum Via Diameter": "16mil (0.4064mm)",
+        "Copper to hole clearance": "5mil (0.127mm)",
+        "Minimum Through Hole": "8mil (0.2032mm)",
+        "Hole to hole clearance": "5mil (0.127mm)",
+        "Minimum uVia diameter": "16mil (0.4064mm)",
+        "minimum uVia Hole": "8mil (0.2032mm)",
+        "Silkscreen Min Item Clearance": "any",
+        "Silkscreen Min Text Height": "any",
+        "Silkscreen Min Text Thickness": "5mil (0.127mm)",
+    },
+}
+
+
 __all__ = [
     "Board",
     "PCB",
@@ -57,4 +107,5 @@ __all__ = [
     "TOP_SILK",
     "BOTTOM_SILK",
     "check_board",
+    "LAYER_SERVICE_RULES",
 ]


### PR DESCRIPTION
## Summary
- define `LAYER_SERVICE_RULES` with design rules for common 2-, 4-, and 6-layer boards
- export the new constant from `boardforge.__init__`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a014d91c88329bbf5bacb69a573bd