### PR TITLE
Implement more DRC rules

### DIFF
--- a/boardforge/Via.py
+++ b/boardforge/Via.py
@@ -1,8 +1,11 @@
 class Via:
 
-    def __init__(self, x, y, from_layer, to_layer):
+    def __init__(self, x, y, from_layer, to_layer, diameter=0.6, hole=0.3):
         self.x = x
         self.y = y
         self.from_layer = from_layer
         self.to_layer = to_layer
+        self.diameter = diameter
+        self.hole = hole
+
 

--- a/boardforge/drc.py
+++ b/boardforge/drc.py
@@ -4,7 +4,17 @@ import math
 from typing import List
 
 
-def check_board(board, min_trace_width: float = 0.15, min_clearance: float = 0.15) -> List[str]:
+def check_board(
+    board,
+    min_trace_width: float = 0.15,
+    min_clearance: float = 0.15,
+    min_annular_ring: float | None = None,
+    min_via_diameter: float | None = None,
+    min_through_hole: float | None = None,
+    hole_to_hole_clearance: float | None = None,
+    min_text_height: float | None = None,
+    min_text_thickness: float | None = None,
+) -> List[str]:
     """Return a list of DRC warnings for a board.
 
     Parameters
@@ -15,6 +25,18 @@ def check_board(board, min_trace_width: float = 0.15, min_clearance: float = 0.1
         Minimum allowed trace width in the board's units (defaults to 0.15).
     min_clearance : float, optional
         Minimum allowed clearance between pad edges (defaults to 0.15).
+    min_annular_ring : float, optional
+        Minimum allowed annular ring width for vias.
+    min_via_diameter : float, optional
+        Minimum allowed overall via diameter.
+    min_through_hole : float, optional
+        Minimum allowed drill size for vias.
+    hole_to_hole_clearance : float, optional
+        Minimum allowed clearance between via holes.
+    min_text_height : float, optional
+        Minimum allowed height for silkscreen text.
+    min_text_thickness : float, optional
+        Minimum allowed thickness for silkscreen text.
     """
 
     warnings = []
@@ -59,4 +81,49 @@ def check_board(board, min_trace_width: float = 0.15, min_clearance: float = 0.1
                     f"Pad clearance between {p1.name} and {p2.name} is {clearance:.3f}mm; minimum {min_clearance}mm"
                 )
 
+    # Via checks
+    for via in board.vias:
+        if min_via_diameter and via.diameter < min_via_diameter:
+            warnings.append(
+                f"Via at ({via.x},{via.y}) diameter {via.diameter}mm below minimum {min_via_diameter}mm"
+            )
+        if min_through_hole and via.hole < min_through_hole:
+            warnings.append(
+                f"Via at ({via.x},{via.y}) hole {via.hole}mm below minimum {min_through_hole}mm"
+            )
+        if min_annular_ring is not None:
+            annular = (via.diameter - via.hole) / 2.0
+            if annular < min_annular_ring:
+                warnings.append(
+                    f"Via at ({via.x},{via.y}) annular ring {annular:.3f}mm below minimum {min_annular_ring}mm"
+                )
+
+    if hole_to_hole_clearance:
+        for i in range(len(board.vias)):
+            for j in range(i + 1, len(board.vias)):
+                v1 = board.vias[i]
+                v2 = board.vias[j]
+                dx = v1.x - v2.x
+                dy = v1.y - v2.y
+                center_dist = math.hypot(dx, dy)
+                clearance = center_dist - (v1.hole / 2) - (v2.hole / 2)
+                if clearance < hole_to_hole_clearance:
+                    warnings.append(
+                        f"Via clearance between ({v1.x},{v1.y}) and ({v2.x},{v2.y}) is {clearance:.3f}mm; minimum {hole_to_hole_clearance}mm"
+                    )
+
+    if (min_text_height or min_text_thickness) and getattr(board, "_svg_text_calls", None):
+        for text, at, size, layer in board._svg_text_calls:
+            if min_text_height and size < min_text_height:
+                warnings.append(
+                    f"Silkscreen text '{text}' height {size}mm below minimum {min_text_height}mm"
+                )
+            if min_text_thickness:
+                thickness = size * 0.2
+                if thickness < min_text_thickness:
+                    warnings.append(
+                        f"Silkscreen text '{text}' thickness {thickness:.3f}mm below minimum {min_text_thickness}mm"
+                    )
+
     return warnings
+

--- a/boardforge/rules.py
+++ b/boardforge/rules.py
@@ -1,5 +1,5 @@
 LAYER_SERVICE_RULES = {
-    "2 Layer Services": {
+    "2 Layer": {
         "Minimum Clearance": "6mil (0.1524mm)",
         "Minimum track Width": "6mil (0.1524mm)",
         "Minimum Connection Width": "6mil (0.1524mm)",

--- a/tests/test_drc.py
+++ b/tests/test_drc.py
@@ -70,3 +70,12 @@ def test_drc_uses_layer_service_defaults():
     warnings = board.design_rule_check()
     assert any("width" in w for w in warnings)
 
+
+def test_via_rules_enforced():
+    board = Board(width=5, height=5)
+    board.set_layer_stack(["GTL", "GBL"])
+    board.add_via(1, 1, diameter=0.3, hole=0.2)
+    board.add_via(1.2, 1, diameter=0.3, hole=0.2)
+    warnings = board.design_rule_check()
+    assert any("Via" in w for w in warnings)
+


### PR DESCRIPTION
## Summary
- rename layer service key to `2 Layer`
- default board layer service updated
- extend design rule checks to handle via properties and silkscreen text
- add via diameter/holes in `Via` class and board API
- test via rule enforcement

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a08d12d808329a223219f4e7c9c9f