### PR TITLE
Raise DRCError on design rule problems

### DIFF
--- a/boardforge/__init__.py
+++ b/boardforge/__init__.py
@@ -5,7 +5,7 @@ from .Via import Via
 from .Graphic import Graphic
 from .Board import Board
 from .Zone import Zone
-from .drc import check_board
+from .drc import check_board, DRCError
 from .rules import LAYER_SERVICE_RULES
 from .circuits import (
     create_voltage_divider,
@@ -58,5 +58,6 @@ __all__ = [
     "TOP_SILK",
     "BOTTOM_SILK",
     "check_board",
+    "DRCError",
     "LAYER_SERVICE_RULES",
 ]

--- a/boardforge/drc.py
+++ b/boardforge/drc.py
@@ -1,5 +1,13 @@
 """Design Rule Checking utilities."""
 
+class DRCError(Exception):
+    """Raised when a design rule violation is detected."""
+
+    def __init__(self, warnings):
+        message = "; ".join(warnings)
+        super().__init__(message)
+        self.warnings = warnings
+
 import math
 from typing import List
 


### PR DESCRIPTION
## Summary
- introduce `DRCError` exception
- update `design_rule_check` to raise `DRCError`
- simplify `export_gerbers` since design rule checks now raise
- expose `DRCError` in public API
- update tests for the new error-based behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0c1878f08329a19ff9862c7e0e62