### PR TITLE
Add PNG preview rendering

### DIFF
--- a/README_V46.md
+++ b/README_V46.md
@@ -121,6 +121,7 @@ Run the script to generate `output/arduino_like.zip` and preview images. See
 - `add_svg_graphic(svg_path, layer, scale=1.0, at=(0,0))`
 - `add_text_ttf(text, font_path, at=(x, y), size=1.0, layer="GTO")`
 - `export_gerbers("output/zipfile.zip")`
+- `save_png_previews(outdir=".", scale=10)`
 
 ### `Component`
 - `add_pin(name, dx, dy)`

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest
 pytest-timeout
 cairosvg
 pillow
+shapely


### PR DESCRIPTION
## Summary
- add new `save_png_previews` for higher quality previews
- document method in API reference
- include `shapely` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a5c4b9e94832983eedcf690608a66