### PR TITLE
Add BoardForge examples adapted from CuFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Log files such as `boardforge.log` may appear when running the demos.
 Example scripts in the `examples/` folder demonstrate advanced usage such as
 the `arduino_like.py` microcontroller board and the
 `buck_boost_converter.py` power module with display and buttons.
+Two additional scripts, `cuflow_demo.py` and `cuflow_clockpwr.py`, are
+adaptations of examples from [James Bowman's CuFlow project](https://github.com/jamesbowman/cuflow).
+These show how similar layouts can be produced using the BoardForge API while
+giving credit to the original CuFlow work.
 
 ## Running the tests
 

--- a/examples/cuflow_clockpwr.py
+++ b/examples/cuflow_clockpwr.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+from boardforge import PCB, Layer
+
+# Adapted from jamesbowman's CuFlow clockpwr.py
+# Original source: https://github.com/jamesbowman/cuflow
+# Demonstrates simple header connections and screw terminals using the BoardForge API.
+
+BASE_DIR = Path(__file__).resolve().parent
+OUTPUT_DIR = BASE_DIR.parent / "output"
+
+
+def build_board():
+    board = PCB(width=80, height=24)
+    board.set_layer_stack([
+        Layer.TOP_COPPER.value,
+        Layer.BOTTOM_COPPER.value,
+        Layer.TOP_SILK.value,
+        Layer.BOTTOM_SILK.value,
+    ])
+
+    # Two 6-pin headers
+    j1 = board.add_component("HDR6", ref="J1", at=(10, 12))
+    j2 = board.add_component("HDR6", ref="J2", at=(70, 12))
+    for i in range(6):
+        dy = -5 + i * 2
+        for j in (j1, j2):
+            j.add_pin(str(i + 1), dx=0, dy=dy)
+            j.add_pad(str(i + 1), dx=0, dy=dy, w=1.2, h=1.2)
+
+    # Three screw terminals top and bottom
+    screws_top = []
+    for dx in (-5, 0, 5):
+        sc = board.add_component("SCREW", ref=f"J3_{dx}", at=(40 + dx, 20))
+        sc.add_pin("P", dx=0, dy=0)
+        sc.add_pad("P", dx=0, dy=0, w=2, h=2)
+        screws_top.append(sc)
+    screws_bot = []
+    for dx in (-5, 0, 5):
+        sc = board.add_component("SCREW", ref=f"J4_{dx}", at=(40 + dx, 4))
+        sc.add_pin("P", dx=0, dy=0)
+        sc.add_pad("P", dx=0, dy=0, w=2, h=2)
+        screws_bot.append(sc)
+
+    # Route header pins 2-5 directly across
+    for i in range(1, 5):
+        board.route_trace(f"J1:{i+1}", f"J2:{i+1}")
+
+    # Connect VCC and GND to screw terminals
+    for screw in screws_top:
+        board.route_trace("J1:1", f"{screw.ref}:P")
+        board.route_trace("J2:1", f"{screw.ref}:P")
+    for screw in screws_bot:
+        board.route_trace("J1:6", f"{screw.ref}:P")
+        board.route_trace("J2:6", f"{screw.ref}:P")
+
+    return board
+
+
+def main():
+    board = build_board()
+    board.save_svg_previews(str(OUTPUT_DIR))
+    board.export_gerbers(OUTPUT_DIR / "cuflow_clockpwr.zip")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cuflow_demo.py
+++ b/examples/cuflow_demo.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from math import sqrt
+from boardforge import PCB, Layer
+
+# Adapted from jamesbowman's CuFlow demo.py
+# Original source: https://github.com/jamesbowman/cuflow
+# This version targets the BoardForge API.
+
+BASE_DIR = Path(__file__).resolve().parent
+OUTPUT_DIR = BASE_DIR.parent / "output"
+
+
+def build_board():
+    board = PCB(width=10, height=10)
+    board.set_layer_stack([
+        Layer.TOP_COPPER.value,
+        Layer.BOTTOM_COPPER.value,
+        Layer.TOP_SILK.value,
+        Layer.BOTTOM_SILK.value,
+    ])
+
+    pitch = 0.8
+    connectors = []
+    for i in range(8):
+        x = 3.6 + i * pitch
+        c = board.add_component("TP", ref=f"P{i+1}", at=(x, 1))
+        c.add_pin("SIG", dx=0, dy=0)
+        c.add_pad("SIG", dx=0, dy=0, w=0.8, h=0.8)
+        connectors.append(c)
+
+    for idx, c in enumerate(connectors):
+        p0 = c.pin("SIG")
+        path = [
+            p0,
+            (p0.x, p0.y + 3),  # forward 3mm
+            (
+                p0.x - 3 / sqrt(2),
+                p0.y + 3 + 3 / sqrt(2),
+            ),  # left 45 deg, 3mm
+            (
+                p0.x - 3 / sqrt(2),
+                p0.y + 3 + 3 / sqrt(2) + 1,
+            ),  # forward 1mm
+        ]
+        layer = Layer.BOTTOM_COPPER.value if idx == len(connectors) - 1 else Layer.TOP_COPPER.value
+        board.trace_path(path, layer=layer)
+
+    return board
+
+
+def main():
+    board = build_board()
+    board.save_svg_previews(str(OUTPUT_DIR))
+    board.export_gerbers(OUTPUT_DIR / "cuflow_demo.zip")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `cuflow_demo.py` and `cuflow_clockpwr.py` adapted from the CuFlow project
- document these new examples in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a5f748e588329b466f624b5050834