### PR TITLE
Add hole support to BoardForge

### DIFF
--- a/boardforge/GerberExporter.py
+++ b/boardforge/GerberExporter.py
@@ -50,6 +50,29 @@ def export_gerbers(board, output_zip_path):
                                 f.write(f"X{x2:07d}Y{y2:07d}D01*\n")
                         else:
                             f.write(f"{line}\n")
+
+        # Drill/hole file
+        if getattr(board, "holes", None):
+            import math
+            holes_path = temp_dir / "holes.gbr"
+            with open(holes_path, "w", encoding="utf-8") as f:
+                f.write("G04 holes *\n")
+                for hx, hy, dia, ann in board.holes:
+                    r = dia / 2.0
+                    for i in range(13):
+                        a = 2 * math.pi * i / 12
+                        x = hx + r * math.cos(a)
+                        y = hy + r * math.sin(a)
+                        code = "D02*" if i == 0 else "D01*"
+                        f.write(f"X{int(x*1000):07d}Y{int(y*1000):07d}{code}\n")
+                    if ann is not None:
+                        rr = r + ann
+                        for i in range(13):
+                            a = 2 * math.pi * i / 12
+                            x = hx + rr * math.cos(a)
+                            y = hy + rr * math.sin(a)
+                            code = "D02*" if i == 0 else "D01*"
+                            f.write(f"X{int(x*1000):07d}Y{int(y*1000):07d}{code}\n")
         
         # Save SVG previews if the method exists
         if hasattr(board, 'save_svg_previews'):

--- a/tests/test_holes.py
+++ b/tests/test_holes.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+import zipfile
+from io import BytesIO
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from boardforge import PCB, Layer
+
+def test_hole_export_and_preview(tmp_path):
+    board = PCB(width=10, height=10)
+    board.set_layer_stack([
+        Layer.TOP_COPPER.value,
+        Layer.BOTTOM_COPPER.value,
+        Layer.TOP_SILK.value,
+        Layer.BOTTOM_SILK.value,
+    ])
+
+    board.hole((5, 5), diameter=2.0, annulus=0.5)
+
+    zip_path = tmp_path / "holes.zip"
+    board.export_gerbers(zip_path)
+
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as z:
+        names = set(z.namelist())
+        assert "holes.gbr" in names
+        data = z.read("holes.gbr").decode()
+        assert "holes" in data.splitlines()[0].lower()
+        png = z.read("preview_top.png") if "preview_top.png" in names else b""
+
+    if png:
+        with Image.open(BytesIO(png)) as img:
+            px = int(5 * 10)
+            assert img.getpixel((px, px)) == (0, 0, 0, 255)


### PR DESCRIPTION
## Summary
- allow boards to record hole locations with new `hole` method
- render holes in SVG and PNG previews
- include holes in Gerber export via `holes.gbr`
- test hole export and preview rendering

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a672375d8832985aacffe4965f6f1