### PR TITLE
Add board outline and fill features

### DIFF
--- a/boardforge/GerberExporter.py
+++ b/boardforge/GerberExporter.py
@@ -51,6 +51,16 @@ def export_gerbers(board, output_zip_path):
                         else:
                             f.write(f"{line}\n")
 
+        # Board outline layer
+        if getattr(board, "outline_geom", None) is not None:
+            outline_path = temp_dir / "GKO.gbr"
+            with open(outline_path, "w", encoding="utf-8") as f:
+                f.write("G04 GKO *\n")
+                coords = list(board.outline_geom.exterior.coords)
+                for i, (x, y) in enumerate(coords):
+                    code = "D02*" if i == 0 else "D01*"
+                    f.write(f"X{int(x*1000):07d}Y{int(y*1000):07d}{code}\n")
+
         # Drill/hole file
         if getattr(board, "holes", None):
             import math

--- a/boardforge/Zone.py
+++ b/boardforge/Zone.py
@@ -1,6 +1,10 @@
+from shapely.geometry import Polygon
+
+
 class Zone:
     """Represents a filled copper area on a given layer."""
 
-    def __init__(self, net=None, layer="GBL"):
+    def __init__(self, net=None, layer="GBL", geometry=None):
         self.net = net
         self.layer = layer
+        self.geometry = Polygon(geometry) if geometry is not None else None

--- a/tests/test_outline_fill.py
+++ b/tests/test_outline_fill.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+import zipfile
+from io import BytesIO
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from boardforge import PCB, Layer
+
+
+def test_outline_and_fill(tmp_path):
+    board = PCB(width=5, height=5)
+    board.set_layer_stack([
+        Layer.TOP_COPPER.value,
+        Layer.BOTTOM_COPPER.value,
+        Layer.TOP_SILK.value,
+        Layer.BOTTOM_SILK.value,
+    ])
+
+    board.outline([(0, 0), (5, 0), (5, 5), (0, 5)])
+    board.fill([(1, 1), (4, 1), (4, 4), (1, 4)], layer=Layer.TOP_COPPER.value)
+
+    zip_path = tmp_path / "out.zip"
+    board.export_gerbers(zip_path)
+
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as z:
+        names = set(z.namelist())
+        assert "GKO.gbr" in names
+        outline_lines = z.read("GKO.gbr").decode().splitlines()
+        assert outline_lines[0].startswith("G04 GKO")
+        assert outline_lines[1] == "X0000000Y0000000D02*"
+        assert outline_lines[-1] == "X0000000Y0000000D01*"
+
+        gtl_lines = z.read("GTL.gbr").decode().splitlines()
+        assert any(l.startswith("X0001000Y0001000D02*") for l in gtl_lines)
+        assert gtl_lines[-1] == "X0001000Y0001000D01*"
+        png = z.read("preview_top.png")
+
+    if png:
+        with Image.open(BytesIO(png)) as img:
+            px = int(2 * 10)
+            assert img.getpixel((px, px)) == (190, 130, 58, 255)
+


### PR DESCRIPTION
## Summary
- support storing board outline geometry
- implement methods to define outlines, expand them and add copper fills
- export outlines in gerber output and include filled polygons in previews
- ensure PNG previews stay RGBA
- add regression test for outline and fill

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6a6375fc8329a4e350e05d37867a