### PR TITLE
Add annotate and logo helpers

### DIFF
--- a/boardforge/Board.py
+++ b/boardforge/Board.py
@@ -187,6 +187,35 @@ class Board:
             print(f"TTF render error: {e}")
         log('EXIT add_text_ttf', {'self': self.__dict__})
 
+    def annotate(self, x, y, text, size=1.0, layer=TOP_SILK):
+        """Add an annotation using the bundled RobotoMono font."""
+        font_path = os.path.join(os.path.dirname(__file__), "..", "fonts", "RobotoMono.ttf")
+        if hasattr(layer, "value"):
+            layer = layer.value
+        self.add_text_ttf(text, font_path=font_path, at=(x, y), size=size, layer=layer)
+
+    def logo(self, x, y, image, scale=1.0, layer=TOP_SILK):
+        """Render a Pillow image onto ``layer`` as a simple bitmap graphic."""
+        if hasattr(layer, "value"):
+            layer = layer.value
+        img = image.convert("RGBA")
+        width, height = img.size
+        for j in range(height):
+            for i in range(width):
+                r, g, b, a = img.getpixel((i, j))
+                if a > 0 and (r, g, b) != (255, 255, 255):
+                    sx = x + i * scale
+                    sy = y + j * scale
+                    cmds = [
+                        f"X{int(sx*1000):07d}Y{int(sy*1000):07d}D02*",
+                        f"X{int((sx+scale)*1000):07d}Y{int(sy*1000):07d}D01*",
+                        f"X{int((sx+scale)*1000):07d}Y{int((sy+scale)*1000):07d}D01*",
+                        f"X{int(sx*1000):07d}Y{int((sy+scale)*1000):07d}D01*",
+                        f"X{int(sx*1000):07d}Y{int(sy*1000):07d}D01*",
+                    ]
+                    self.layers[layer].extend(cmds)
+
+
     def design_rule_check(self, min_trace_width=None, min_clearance=None):
         """Check design rules and raise :class:`~boardforge.drc.DRCError` on failures.
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from boardforge import Board, Layer
+
+
+def test_annotate_adds_commands():
+    b = Board(width=5, height=5)
+    b.set_layer_stack([Layer.TOP_SILK.value])
+    b.annotate(1, 1, "A", size=1.0, layer=Layer.TOP_SILK)
+    assert len(b.layers[Layer.TOP_SILK.value]) > 0
+
+
+def test_logo_adds_commands():
+    b = Board(width=5, height=5)
+    b.set_layer_stack([Layer.TOP_SILK.value])
+    img = Image.new("RGB", (2, 2), "white")
+    img.putpixel((0, 0), (0, 0, 0))
+    b.logo(0, 0, img, scale=0.5, layer=Layer.TOP_SILK)
+    assert len(b.layers[Layer.TOP_SILK.value]) > 0


### PR DESCRIPTION
## Summary
- wrap `add_text_ttf` with new `Board.annotate`
- convert Pillow images into simple graphics via `Board.logo`
- test that annotate and logo insert drawable data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6e9436b883299c64a6ced71405f9