### PR TITLE
Add simplified CuFlow Dazzler example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Log files such as `boardforge.log` may appear when running the demos.
 Example scripts in the `examples/` folder demonstrate advanced usage such as
 the `arduino_like.py` microcontroller board and the
 `buck_boost_converter.py` power module with display and buttons.
-Two additional scripts, `cuflow_demo.py` and `cuflow_clockpwr.py`, are
-adaptations of examples from [James Bowman's CuFlow project](https://github.com/jamesbowman/cuflow).
+Three scripts, `cuflow_demo.py`, `cuflow_clockpwr.py`, and
+`cuflow_dazzler.py`, are adaptations of examples from
+[James Bowman's CuFlow project](https://github.com/jamesbowman/cuflow).
 These show how similar layouts can be produced using the BoardForge API while
 giving credit to the original CuFlow work.
 

--- a/examples/cuflow_dazzler.py
+++ b/examples/cuflow_dazzler.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+from boardforge import PCB, Layer
+
+# Adapted from jamesbowman's CuFlow dazzler.py
+# Original source: https://github.com/jamesbowman/cuflow
+# Simplified for the BoardForge API.
+
+BASE_DIR = Path(__file__).resolve().parent
+OUTPUT_DIR = BASE_DIR.parent / "output"
+
+
+def build_board():
+    board = PCB(width=50, height=42)
+    board.set_layer_stack([
+        Layer.TOP_COPPER.value,
+        Layer.BOTTOM_COPPER.value,
+        Layer.TOP_SILK.value,
+        Layer.BOTTOM_SILK.value,
+    ])
+
+    pitch = 2.0
+    top = []
+    bottom = []
+
+    for i in range(10):
+        x = 5 + i * pitch
+        c = board.add_component("TP", ref=f"T{i+1}", at=(x, 40))
+        c.add_pin("SIG", dx=0, dy=0)
+        c.add_pad("SIG", dx=0, dy=0, w=1.2, h=1.2)
+        top.append(c)
+
+    for i in range(10):
+        x = 5 + i * pitch
+        c = board.add_component("TP", ref=f"B{i+1}", at=(x, 2))
+        c.add_pin("SIG", dx=0, dy=0)
+        c.add_pad("SIG", dx=0, dy=0, w=1.2, h=1.2)
+        bottom.append(c)
+
+    for t, b in zip(top, bottom):
+        board.route_trace(f"{t.ref}:SIG", f"{b.ref}:SIG", layer=Layer.TOP_COPPER.value)
+
+    board.outline([(0, 0), (50, 0), (50, 42), (0, 42), (0, 0)])
+
+    return board
+
+
+def main():
+    board = build_board()
+    board.save_svg_previews(str(OUTPUT_DIR))
+    board.export_gerbers(OUTPUT_DIR / "cuflow_dazzler.zip")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dazzler.py
+++ b/tests/test_dazzler.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+import zipfile
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from examples import cuflow_dazzler
+
+
+def test_dazzler_board(tmp_path):
+    board = cuflow_dazzler.build_board()
+    board.save_svg_previews(tmp_path)
+    zip_path = tmp_path / "dazzler.zip"
+    board.export_gerbers(zip_path)
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as z:
+        names = set(z.namelist())
+        assert {"GTL.gbr", "GBL.gbr", "GTO.gbr", "GBO.gbr",
+                "preview_top.svg", "preview_bottom.svg",
+                "preview_top.png", "preview_bottom.png"}.issubset(names)


### PR DESCRIPTION
## Summary
- adapt CuFlow dazzler example for BoardForge API
- add test verifying Gerbers and previews
- reference new example in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a71253e408329abd88b0f6b175ccf