### PR TITLE
Fix add_component exit logging and add regression test

### DIFF
--- a/boardforge/Board.py
+++ b/boardforge/Board.py
@@ -60,8 +60,8 @@ class Board:
         comp = Component(ref, type, at, rotation)
         self.components.append(comp)
         self._ref_map[ref] = comp
-        return comp
         log('EXIT add_component', {'self': self.__dict__})
+        return comp
 
     def trace(self, pin1, pin2, layer="GTL", width=1.0):
         """Add a simple straight trace between two pins."""

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+import sys
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from boardforge import PCB
+
+
+def test_add_component_logging(tmp_path):
+    # run in isolated directory so log file doesn't interfere
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        board = PCB(width=5, height=5)
+        board.add_component("RES", ref="R1", at=(0, 0))
+        log_path = tmp_path / "boardforge.log"
+        assert log_path.exists(), "boardforge.log should be created"
+        log_contents = log_path.read_text()
+        assert "ENTER add_component" in log_contents
+        assert "EXIT add_component" in log_contents
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
## Summary
- ensure `add_component` logs on exit before returning
- add regression test for logging of component addition

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a74eabda8832987d4d46dca6027ba