### PR TITLE
Add dazzler_full example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,13 @@ the `arduino_like.py` microcontroller board and the
 `buck_boost_converter.py` power module with display and buttons.
 The repository also adapts several of
 [James Bowman's CuFlow project](https://github.com/jamesbowman/cuflow)
-examples. Currently `cuflow_demo.py` and `cuflow_clockpwr.py` are available,
-and the `examples/cuflow_dazzler.py` script provides a simplified Dazzler
-adaptation. These scripts translate the original CuFlow commands into
-BoardForge's higher level PCB API, showing how similar layouts can be produced
-while crediting the original CuFlow work.
+examples. Currently `cuflow_demo.py` and `cuflow_clockpwr.py` are available.
+The `examples/cuflow_dazzler.py` script provides a simplified Dazzler
+adaptation, while `examples/dazzler_full.py` demonstrates a more complete port
+with mounting holes, copper fills and silkscreen graphics. These scripts
+translate the original CuFlow commands into BoardForge's higher level PCB API,
+showing how similar layouts can be produced while crediting the original
+CuFlow work.
 
 ## Running the tests
 

--- a/examples/dazzler_full.py
+++ b/examples/dazzler_full.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+from PIL import Image, ImageDraw
+from boardforge import PCB, Layer
+
+BASE_DIR = Path(__file__).resolve().parent
+FONT_PATH = BASE_DIR.parent / "fonts" / "RobotoMono.ttf"
+GRAPHIC_PATH = BASE_DIR.parent / "graphics" / "torch.svg"
+OUTPUT_DIR = BASE_DIR.parent / "output"
+
+
+def build_board():
+    board = PCB(width=50, height=42)
+    board.set_layer_stack([
+        Layer.TOP_COPPER.value,
+        Layer.BOTTOM_COPPER.value,
+        Layer.TOP_SILK.value,
+        Layer.BOTTOM_SILK.value,
+    ])
+
+    w, h, ch = 50, 42, 3
+    outline = [
+        (ch, 0), (w - ch, 0), (w, ch),
+        (w, h - ch), (w - ch, h), (ch, h),
+        (0, h - ch), (0, ch),
+    ]
+    board.outline(outline)
+
+    for x, y in [(3, 3), (w - 3, 3), (w - 3, h - 3), (3, h - 3)]:
+        board.hole((x, y), diameter=2.5)
+
+    for dx in [-5, 0, 5]:
+        board.hole((w/2 + dx, 5), diameter=1.2)
+
+    fpga = board.add_component("FPGA", ref="U1", at=(w/2, h/2))
+    for i, (dx, dy) in enumerate([(-3, -3), (-3, 3), (3, -3), (3, 3)], start=1):
+        fpga.add_pin(f"P{i}", dx=dx, dy=dy)
+        fpga.add_pad(f"P{i}", dx=dx, dy=dy, w=1.2, h=1.2)
+
+    board.fill([(10, 20), (40, 20), (40, 30), (10, 30)], layer=Layer.BOTTOM_COPPER.value)
+
+    board.annotate(5, 38, "Dazzler", size=1.5, layer=Layer.TOP_SILK)
+    if GRAPHIC_PATH.exists():
+        board.add_svg_graphic(str(GRAPHIC_PATH), layer=Layer.TOP_SILK.value, scale=0.5, at=(2, 2))
+
+    img = Image.new("RGBA", (3, 3), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    draw.rectangle([0, 0, 2, 2], fill=(255, 0, 0, 255))
+    board.logo(45, 35, img, scale=0.5, layer=Layer.TOP_SILK)
+
+    return board
+
+
+def main():
+    board = build_board()
+    board.save_svg_previews(str(OUTPUT_DIR))
+    board.export_gerbers(OUTPUT_DIR / "dazzler_full.zip")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dazzler_full.py
+++ b/tests/test_dazzler_full.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import zipfile
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from examples import dazzler_full
+
+
+def test_dazzler_full_board(tmp_path):
+    board = dazzler_full.build_board()
+    board.save_svg_previews(tmp_path)
+    zip_path = tmp_path / "dazzler_full.zip"
+    board.export_gerbers(zip_path)
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as z:
+        names = set(z.namelist())
+        assert {
+            "GTL.gbr",
+            "GBL.gbr",
+            "GTO.gbr",
+            "GBO.gbr",
+            "preview_top.svg",
+            "preview_bottom.svg",
+            "preview_top.png",
+            "preview_bottom.png",
+        }.issubset(names)


### PR DESCRIPTION
## Summary
- create `examples/dazzler_full.py` showcasing BoardForge APIs (`hole`, `fill`, `logo`, `annotate`)
- test that `dazzler_full.py` exports preview and gerber files
- mention the new example in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687abfd9e0a4832986c8f430de4b8e5c