### PR TITLE
Update README and add dev requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ CuFlow work.
 
 ## Running the tests
 
-Install the dependencies and execute the test suite:
+Install the dependencies before running the test suite:
 
 ```bash
 pip install -r requirements.txt
 pytest
 ```
+An optional `requirements-dev.txt` pins the package versions used in CI.
 
 ## License
 

--- a/README_V46.md
+++ b/README_V46.md
@@ -28,12 +28,14 @@ pip install -r requirements.txt
 
 ### Testing
 
-The tests are executed with `pytest`.  The `pytest-timeout` plugin is enabled
+The tests are executed with `pytest`. Be sure to install the dependencies first
+using `pip install -r requirements.txt`. The `pytest-timeout` plugin is enabled
 so each test is limited to five seconds.
 
 ```bash
 pytest
 ```
+An optional `requirements-dev.txt` pins the package versions used in CI.
 
 ## 📁 Folder Structure
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+freetype-py==2.5.1
+svg.path==7.0
+fonttools==4.59.0
+pytest==8.4.1
+pytest-timeout==2.4.0
+cairosvg==2.8.2
+pillow==11.3.0
+shapely==2.1.1


### PR DESCRIPTION
## Summary
- clarify that dependencies must be installed before running tests
- describe optional requirements-dev.txt used by CI
- pin package versions in requirements-dev.txt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b2de05ca883299705fa5a245b99d6