### PR TITLE
Add chamfered outline helper

### DIFF
--- a/boardforge/Board.py
+++ b/boardforge/Board.py
@@ -128,6 +128,33 @@ class Board:
         self.outline_geom = Polygon(points)
         return self.outline_geom
 
+    def chamfer_outline(self, width, height, chamfer):
+        """Create a chamfered rectangular outline.
+
+        Parameters
+        ----------
+        width : float
+            Overall board width.
+        height : float
+            Overall board height.
+        chamfer : float
+            Offset distance from each corner for the chamfer.
+        """
+        self.width = width
+        self.height = height
+        pts = [
+            (chamfer, 0),
+            (width - chamfer, 0),
+            (width, chamfer),
+            (width, height - chamfer),
+            (width - chamfer, height),
+            (chamfer, height),
+            (0, height - chamfer),
+            (0, chamfer),
+        ]
+        self.outline_geom = Polygon(pts)
+        return self.outline_geom
+
     def oversize(self, margin):
         """Expand the stored outline by ``margin`` mm."""
         if self.outline_geom is None:

--- a/boardforge/__init__.py
+++ b/boardforge/__init__.py
@@ -4,6 +4,9 @@ from .Component import Component
 from .Via import Via
 from .Graphic import Graphic
 from .Board import Board
+
+# Expose useful Board helper methods at module level
+chamfer_outline = Board.chamfer_outline
 from .Zone import Zone
 from .drc import check_board, DRCError
 from .rules import LAYER_SERVICE_RULES
@@ -55,6 +58,7 @@ __all__ = [
     "create_led_indicator",
     "create_rc_lowpass",
     "create_bent_trace",
+    "chamfer_outline",
     "TOP_SILK",
     "BOTTOM_SILK",
     "check_board",

--- a/examples/dazzler_full.py
+++ b/examples/dazzler_full.py
@@ -18,12 +18,7 @@ def build_board():
     ])
 
     w, h, ch = 50, 42, 3
-    outline = [
-        (ch, 0), (w - ch, 0), (w, ch),
-        (w, h - ch), (w - ch, h), (ch, h),
-        (0, h - ch), (0, ch),
-    ]
-    board.outline(outline)
+    board.chamfer_outline(w, h, ch)
 
     for x, y in [(3, 3), (w - 3, 3), (w - 3, h - 3), (3, h - 3)]:
         board.hole((x, y), diameter=2.5)

--- a/tests/test_chamfer.py
+++ b/tests/test_chamfer.py
@@ -1,0 +1,38 @@
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from boardforge import PCB, Layer
+
+
+def test_chamfer_outline(tmp_path):
+    board = PCB(width=10, height=8)
+    board.set_layer_stack([Layer.TOP_COPPER.value, Layer.BOTTOM_COPPER.value])
+    board.chamfer_outline(10, 8, 2)
+
+    zip_path = tmp_path / "out.zip"
+    board.export_gerbers(zip_path)
+    assert zip_path.exists()
+
+    with zipfile.ZipFile(zip_path) as z:
+        lines = z.read("GKO.gbr").decode().splitlines()
+
+    coords = lines[1:]
+    assert len(coords) == 9  # 8 vertices + closing point
+
+    pts = []
+    for l in coords[:-1]:
+        m = re.match(r"X(\d+)Y(\d+)D0[12]\*", l)
+        assert m
+        pts.append((int(m.group(1)) / 1000, int(m.group(2)) / 1000))
+
+    expected = [
+        (2, 0), (8, 0), (10, 2),
+        (10, 6), (8, 8), (2, 8),
+        (0, 6), (0, 2),
+    ]
+    assert pts == expected


### PR DESCRIPTION
## Summary
- add Board.chamfer_outline helper
- expose helper at package level
- test chamfered outline gerber output
- use new helper in `dazzler_full` example

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b86968ae08329806a5519773fa0bf