### PR TITLE
Add advanced dazzler example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ The repository also adapts several of
 examples. Currently `cuflow_demo.py` and `cuflow_clockpwr.py` are available.
 The `examples/cuflow_dazzler.py` script provides a simplified Dazzler
 adaptation, while `examples/dazzler_full.py` demonstrates a more complete port
-with mounting holes, copper fills and silkscreen graphics. These scripts
-translate the original CuFlow commands into BoardForge's higher level PCB API,
-showing how similar layouts can be produced while crediting the original
-CuFlow work.
+with mounting holes, copper fills and silkscreen graphics. The
+`examples/dazzler_advanced.py` demo combines these ideas with rows of pads on
+every edge of a chamfered 50×42 mm board. These scripts translate the original
+CuFlow commands into BoardForge's higher level PCB API, showing how similar
+layouts can be produced while crediting the original CuFlow work.
 
 ## Running the tests
 

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,22 @@
+"""Example boards packaged with BoardForge."""
+
+from importlib import import_module
+
+__all__ = [
+    "arduino_like",
+    "bent_trace",
+    "buck_boost_converter",
+    "cuflow_clockpwr",
+    "cuflow_dazzler",
+    "cuflow_demo",
+    "dazzler_full",
+    "dazzler_advanced",
+    "esp32_dev_board",
+]
+
+# Lazily import submodules when accessed
+
+def __getattr__(name):
+    if name in __all__:
+        return import_module(f"{__name__}.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/examples/dazzler_advanced.py
+++ b/examples/dazzler_advanced.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+from boardforge import PCB, Layer
+
+BASE_DIR = Path(__file__).resolve().parent
+FONT_PATH = BASE_DIR.parent / "fonts" / "RobotoMono.ttf"
+OUTPUT_DIR = BASE_DIR.parent / "output"
+
+
+def build_board():
+    board = PCB(width=50, height=42)
+    board.set_layer_stack([
+        Layer.TOP_COPPER.value,
+        Layer.BOTTOM_COPPER.value,
+        Layer.TOP_SILK.value,
+        Layer.BOTTOM_SILK.value,
+    ])
+
+    w, h, ch = 50, 42, 3
+    board.chamfer_outline(w, h, ch)
+
+    # Mounting holes in each corner
+    for x, y in [(3, 3), (w-3, 3), (w-3, h-3), (3, h-3)]:
+        board.hole((x, y), diameter=2.5)
+
+    # Left edge pads (15)
+    lpitch = (h - 6) / 14
+    for i in range(15):
+        y = 3 + i * lpitch
+        c = board.add_component("TP", ref=f"L{i+1}", at=(1.5, y))
+        c.add_pin("SIG", dx=0, dy=0)
+        c.add_pad("SIG", dx=0, dy=0, w=1.0, h=1.0)
+
+    # Right edge pads (16)
+    rpitch = (h - 6) / 15
+    for i in range(16):
+        y = 3 + i * rpitch
+        c = board.add_component("TP", ref=f"R{i+1}", at=(w-1.5, y))
+        c.add_pin("SIG", dx=0, dy=0)
+        c.add_pad("SIG", dx=0, dy=0, w=1.0, h=1.0)
+
+    # Optional top edge pads (5)
+    tpitch = (w - 10) / 4
+    for i in range(5):
+        x = 5 + i * tpitch
+        c = board.add_component("TP", ref=f"T{i+1}", at=(x, h-1.5))
+        c.add_pin("SIG", dx=0, dy=0)
+        c.add_pad("SIG", dx=0, dy=0, w=1.0, h=1.0)
+
+    # Optional bottom edge pads (3)
+    bpitch = (w - 20) / 2
+    for i in range(3):
+        x = 10 + i * bpitch
+        c = board.add_component("TP", ref=f"B{i+1}", at=(x, 1.5))
+        c.add_pin("SIG", dx=0, dy=0)
+        c.add_pad("SIG", dx=0, dy=0, w=1.0, h=1.0)
+
+    # Copper fill on bottom layer
+    board.fill([(5, 5), (w-5, 5), (w-5, h-5), (5, h-5)], layer=Layer.BOTTOM_COPPER.value)
+
+    # Silkscreen label
+    board.add_text_ttf("Dazzler Advanced", font_path=str(FONT_PATH), at=(10, h/2), size=1.5, layer=Layer.TOP_SILK.value)
+
+    return board
+
+
+def main():
+    board = build_board()
+    board.save_svg_previews(str(OUTPUT_DIR))
+    board.export_gerbers(OUTPUT_DIR / "dazzler_advanced.zip")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dazzler_advanced.py
+++ b/tests/test_dazzler_advanced.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import zipfile
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from examples import dazzler_advanced
+
+
+def test_dazzler_advanced_board(tmp_path):
+    board = dazzler_advanced.build_board()
+    board.save_svg_previews(tmp_path)
+    zip_path = tmp_path / "dazzler_advanced.zip"
+    board.export_gerbers(zip_path)
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as z:
+        names = set(z.namelist())
+        assert {
+            "GTL.gbr",
+            "GBL.gbr",
+            "GTO.gbr",
+            "GBO.gbr",
+            "preview_top.svg",
+            "preview_bottom.svg",
+            "preview_top.png",
+            "preview_bottom.png",
+        }.issubset(names)


### PR DESCRIPTION
## Summary
- add `dazzler_advanced.py` example placing pads on all sides of a chamfered board
- export the new example module via `examples/__init__.py`
- document the example in the main README
- test that the example generates gerbers and preview images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b88f15f4883298527858fb7d42264