### PR TITLE
Add dazzler mega example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ with mounting holes, copper fills and silkscreen graphics. The
 every edge of a chamfered 50×42 mm board. These scripts translate the original
 CuFlow commands into BoardForge's higher level PCB API, showing how similar
 layouts can be produced while crediting the original CuFlow work.
+The new `examples/dazzler_mega.py` merges all of these demos into one
+comprehensive script.
 
 ## Running the tests
 

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "cuflow_demo",
     "dazzler_full",
     "dazzler_advanced",
+    "dazzler_mega",
     "esp32_dev_board",
 ]
 

--- a/examples/dazzler_mega.py
+++ b/examples/dazzler_mega.py
@@ -1,0 +1,113 @@
+from pathlib import Path
+from PIL import Image, ImageDraw
+from boardforge import PCB, Layer
+
+BASE_DIR = Path(__file__).resolve().parent
+FONT_PATH = BASE_DIR.parent / "fonts" / "RobotoMono.ttf"
+GRAPHIC_PATH = BASE_DIR.parent / "graphics" / "torch.svg"
+OUTPUT_DIR = BASE_DIR.parent / "output"
+
+
+def build_board():
+    board = PCB(width=50, height=42)
+    board.set_layer_stack([
+        Layer.TOP_COPPER.value,
+        Layer.BOTTOM_COPPER.value,
+        Layer.TOP_SILK.value,
+        Layer.BOTTOM_SILK.value,
+    ])
+
+    w, h, ch = 50, 42, 3
+    board.chamfer_outline(w, h, ch)
+
+    # Corner mounting holes
+    for x, y in [(3, 3), (w-3, 3), (w-3, h-3), (3, h-3)]:
+        board.hole((x, y), diameter=2.5)
+
+    # Additional top edge holes
+    for dx in [-5, 0, 5]:
+        board.hole((w/2 + dx, 5), diameter=1.2)
+
+    # Left edge pads
+    lpitch = (h - 6) / 14
+    for i in range(15):
+        y = 3 + i * lpitch
+        c = board.add_component("TP", ref=f"L{i+1}", at=(1.5, y))
+        c.add_pin("SIG", dx=0, dy=0)
+        c.add_pad("SIG", dx=0, dy=0, w=1.0, h=1.0)
+
+    # Right edge pads
+    rpitch = (h - 6) / 15
+    for i in range(16):
+        y = 3 + i * rpitch
+        c = board.add_component("TP", ref=f"R{i+1}", at=(w-1.5, y))
+        c.add_pin("SIG", dx=0, dy=0)
+        c.add_pad("SIG", dx=0, dy=0, w=1.0, h=1.0)
+
+    # Top edge pads
+    tpitch = (w - 10) / 4
+    for i in range(5):
+        x = 5 + i * tpitch
+        c = board.add_component("TP", ref=f"T{i+1}", at=(x, h-1.5))
+        c.add_pin("SIG", dx=0, dy=0)
+        c.add_pad("SIG", dx=0, dy=0, w=1.0, h=1.0)
+
+    # Bottom edge pads
+    bpitch = (w - 20) / 2
+    for i in range(3):
+        x = 10 + i * bpitch
+        c = board.add_component("TP", ref=f"B{i+1}", at=(x, 1.5))
+        c.add_pin("SIG", dx=0, dy=0)
+        c.add_pad("SIG", dx=0, dy=0, w=1.0, h=1.0)
+
+    # CuFlow style test points connected with traces
+    pitch = 2.0
+    top_points = []
+    bottom_points = []
+    for i in range(10):
+        x = 5 + i * pitch
+        c = board.add_component("TP", ref=f"CT{i+1}", at=(x, h-7))
+        c.add_pin("SIG", dx=0, dy=0)
+        c.add_pad("SIG", dx=0, dy=0, w=1.2, h=1.2)
+        top_points.append(c)
+
+    for i in range(10):
+        x = 5 + i * pitch
+        c = board.add_component("TP", ref=f"CB{i+1}", at=(x, 7))
+        c.add_pin("SIG", dx=0, dy=0)
+        c.add_pad("SIG", dx=0, dy=0, w=1.2, h=1.2)
+        bottom_points.append(c)
+
+    for t, b in zip(top_points, bottom_points):
+        board.route_trace(f"{t.ref}:SIG", f"{b.ref}:SIG", layer=Layer.TOP_COPPER.value)
+
+    # Central FPGA component
+    fpga = board.add_component("FPGA", ref="U1", at=(w/2, h/2))
+    for i, (dx, dy) in enumerate([(-3, -3), (-3, 3), (3, -3), (3, 3)], start=1):
+        fpga.add_pin(f"P{i}", dx=dx, dy=dy)
+        fpga.add_pad(f"P{i}", dx=dx, dy=dy, w=1.2, h=1.2)
+
+    # Copper fill
+    board.fill([(5, 5), (w-5, 5), (w-5, h-5), (5, h-5)], layer=Layer.BOTTOM_COPPER.value)
+
+    # Silkscreen text and graphics
+    board.annotate(5, 38, "Dazzler Mega", size=1.5, layer=Layer.TOP_SILK)
+    board.add_text_ttf("Mega Example", font_path=str(FONT_PATH), at=(10, h/2), size=1.5, layer=Layer.TOP_SILK.value)
+    if GRAPHIC_PATH.exists():
+        board.add_svg_graphic(str(GRAPHIC_PATH), layer=Layer.TOP_SILK.value, scale=0.5, at=(2, 2))
+    img = Image.new("RGBA", (3, 3), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    draw.rectangle([0, 0, 2, 2], fill=(255, 0, 0, 255))
+    board.logo(45, 35, img, scale=0.5, layer=Layer.TOP_SILK)
+
+    return board
+
+
+def main():
+    board = build_board()
+    board.save_svg_previews(str(OUTPUT_DIR))
+    board.export_gerbers(OUTPUT_DIR / "dazzler_mega.zip")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dazzler_mega.py
+++ b/tests/test_dazzler_mega.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import zipfile
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from examples import dazzler_mega
+
+
+def test_dazzler_mega_board(tmp_path):
+    board = dazzler_mega.build_board()
+    board.save_svg_previews(tmp_path)
+    zip_path = tmp_path / "dazzler_mega.zip"
+    board.export_gerbers(zip_path)
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as z:
+        names = set(z.namelist())
+        assert {
+            "GTL.gbr",
+            "GBL.gbr",
+            "GTO.gbr",
+            "GBO.gbr",
+            "preview_top.svg",
+            "preview_bottom.svg",
+            "preview_top.png",
+            "preview_bottom.png",
+        }.issubset(names)


### PR DESCRIPTION
## Summary
- combine all dazzler board demos into `dazzler_mega.py`
- expose the new example from `examples.__init__`
- mention the mega example in the README
- add pytest coverage for the combined script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd930ed948329a790c72375a9ab00