### PR TITLE
Add cross-platform setup scripts for Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ a single comprehensive example. These scripts translate the original CuFlow
 commands into BoardForge's higher level PCB API, showing how similar layouts
 can be produced while crediting the original CuFlow work.
 
+## Setup scripts
+
+Scripts in the `scripts/` folder help install Python 3 and the required packages.
+Run the script that matches your platform from the repository root:
+
+- `scripts/setup_linux.sh` – for Linux distributions using apt, yum, dnf, pacman or zypper
+- `scripts/setup_mac.sh` – for macOS using Homebrew
+- `scripts/setup_windows.bat` – for Windows using winget or Chocolatey
+
+Each script checks for Python 3 and then installs `requirements.txt`.
+
 ## Running the tests
 
 Install the dependencies before running the test suite:

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+# Check for Python 3
+if command -v python3 >/dev/null 2>&1; then
+    echo "Python is already installed: $(python3 --version)"
+else
+    echo "Python 3 not found. Attempting to install..."
+    if command -v apt-get >/dev/null 2>&1; then
+        sudo apt-get update
+        sudo apt-get install -y python3 python3-pip
+    elif command -v yum >/dev/null 2>&1; then
+        sudo yum install -y python3 python3-pip
+    elif command -v dnf >/dev/null 2>&1; then
+        sudo dnf install -y python3 python3-pip
+    elif command -v pacman >/dev/null 2>&1; then
+        sudo pacman -Sy --noconfirm python python-pip
+    elif command -v zypper >/dev/null 2>&1; then
+        sudo zypper install -y python3 python3-pip
+    else
+        echo "Could not detect package manager. Please install Python manually."
+        exit 1
+    fi
+fi
+
+# Ensure pip is available
+if ! command -v pip3 >/dev/null 2>&1; then
+    echo "pip3 not found. Installing with ensurepip..."
+    python3 -m ensurepip --upgrade
+fi
+
+# Install project dependencies
+pip3 install -r requirements.txt
+
+echo "Setup complete."

--- a/scripts/setup_mac.sh
+++ b/scripts/setup_mac.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+# Check for Python 3
+if command -v python3 >/dev/null 2>&1; then
+    echo "Python is already installed: $(python3 --version)"
+else
+    echo "Python 3 not found. Attempting to install via Homebrew..."
+    if command -v brew >/dev/null 2>&1; then
+        brew update
+        brew install python
+    else
+        echo "Homebrew is not installed. Please install Python manually from https://www.python.org/"
+        exit 1
+    fi
+fi
+
+# Ensure pip is available
+if ! command -v pip3 >/dev/null 2>&1; then
+    echo "pip3 not found. Installing with ensurepip..."
+    python3 -m ensurepip --upgrade
+fi
+
+# Install project dependencies
+pip3 install -r requirements.txt
+
+echo "Setup complete."

--- a/scripts/setup_windows.bat
+++ b/scripts/setup_windows.bat
@@ -1,0 +1,27 @@
+@echo off
+SETLOCAL
+
+where python >NUL 2>&1
+IF %ERRORLEVEL% EQU 0 (
+    echo Python is already installed.
+) ELSE (
+    echo Python not found. Attempting to install...
+    where winget >NUL 2>&1
+    IF %ERRORLEVEL% EQU 0 (
+        winget install -e --id Python.Python.3
+    ) ELSE (
+        where choco >NUL 2>&1
+        IF %ERRORLEVEL% EQU 0 (
+            choco install -y python
+        ) ELSE (
+            echo Could not find winget or choco for automatic install.
+            echo Please download and install Python from https://www.python.org/
+            EXIT /B 1
+        )
+    )
+)
+
+python -m pip install -r requirements.txt
+
+ECHO Setup complete.
+ENDLOCAL


### PR DESCRIPTION
## Summary
- add `setup_linux.sh`, `setup_mac.sh`, and `setup_windows.bat` scripts
- document new setup scripts in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be796942883299b1140a2177ed150