### PR TITLE
Add footprint library and loader

### DIFF
--- a/boardforge/Component.py
+++ b/boardforge/Component.py
@@ -32,3 +32,10 @@ class Component:
 
     def pin(self, name):
         return self.pins.get(name)
+
+    def load_footprint(self, name):
+        """Populate this component using a named footprint."""
+        from .footprints import get_footprint
+        loader = get_footprint(name)
+        loader(self)
+        return self

--- a/boardforge/footprints/__init__.py
+++ b/boardforge/footprints/__init__.py
@@ -1,0 +1,32 @@
+from typing import Callable
+from ..Component import Component
+
+from ..__init__ import Footprint
+
+from .c0603 import apply as _c0603
+from .tactile_switch import apply as _tactile_switch
+from .header_1x5 import apply as _header_1x5
+from .sop16 import apply as _sop16
+from .sot223 import apply as _sot223
+from .usb_c_cutout import apply as _usb_c_cutout
+from .esp32_wroom import apply as _esp32_wroom
+from .hdmi import apply as _hdmi
+
+
+_MAPPING = {
+    Footprint.C0603.value: _c0603,
+    Footprint.TACTILE_SWITCH.value: _tactile_switch,
+    Footprint.HEADER_1x5.value: _header_1x5,
+    Footprint.SOP16.value: _sop16,
+    Footprint.SOT223.value: _sot223,
+    Footprint.USB_C_CUTOUT.value: _usb_c_cutout,
+    Footprint.ESP32_WROOM.value: _esp32_wroom,
+    "HDMI": _hdmi,
+}
+
+
+def get_footprint(name: str) -> Callable[[Component], None]:
+    try:
+        return _MAPPING[name]
+    except KeyError:
+        raise ValueError(f"Unknown footprint: {name}")

--- a/boardforge/footprints/c0603.py
+++ b/boardforge/footprints/c0603.py
@@ -1,0 +1,10 @@
+from ..Component import Component
+
+PITCH = 1.0
+
+
+def apply(component: Component):
+    component.add_pin("1", dx=-PITCH/2, dy=0)
+    component.add_pin("2", dx=PITCH/2, dy=0)
+    component.add_pad("1", dx=-PITCH/2, dy=0, w=0.8, h=0.9)
+    component.add_pad("2", dx=PITCH/2, dy=0, w=0.8, h=0.9)

--- a/boardforge/footprints/esp32_wroom.py
+++ b/boardforge/footprints/esp32_wroom.py
@@ -1,0 +1,13 @@
+from ..Component import Component
+
+PITCH = 2.0
+ROW = 18.0
+
+
+def apply(component: Component):
+    for i in range(19):
+        dy = (i - 9) * PITCH
+        component.add_pin(f"P{i+1}", dx=-ROW/2, dy=dy)
+        component.add_pad(f"P{i+1}", dx=-ROW/2, dy=dy, w=1.0, h=1.5)
+        component.add_pin(f"P{i+20}", dx=ROW/2, dy=dy)
+        component.add_pad(f"P{i+20}", dx=ROW/2, dy=dy, w=1.0, h=1.5)

--- a/boardforge/footprints/hdmi.py
+++ b/boardforge/footprints/hdmi.py
@@ -1,0 +1,18 @@
+from ..Component import Component
+
+PITCH = 0.5
+WIDTH = 9.0
+
+
+def apply(component: Component):
+    # Signal pins
+    for i in range(19):
+        x = -4.5 + i * PITCH
+        component.add_pin(f"P{i+1}", dx=x, dy=0)
+        component.add_pad(f"P{i+1}", dx=x, dy=0, w=0.3, h=2.6)
+    # Mechanical pads
+    mech = [(-WIDTH/2, -2.4), (WIDTH/2, -2.4), (-WIDTH/2, 2.4), (WIDTH/2, 2.4)]
+    for j, (dx, dy) in enumerate(mech, start=1):
+        name = f"M{j}"
+        component.add_pin(name, dx=dx, dy=dy)
+        component.add_pad(name, dx=dx, dy=dy, w=1.5, h=1.5)

--- a/boardforge/footprints/header_1x5.py
+++ b/boardforge/footprints/header_1x5.py
@@ -1,0 +1,11 @@
+from ..Component import Component
+
+PITCH = 2.54
+
+
+def apply(component: Component):
+    for i in range(5):
+        dy = i * PITCH
+        name = str(i + 1)
+        component.add_pin(name, dx=0, dy=dy)
+        component.add_pad(name, dx=0, dy=dy, w=1.0, h=1.5)

--- a/boardforge/footprints/sop16.py
+++ b/boardforge/footprints/sop16.py
@@ -1,0 +1,13 @@
+from ..Component import Component
+
+PITCH = 1.27
+ROW = 4.0
+
+
+def apply(component: Component):
+    for i in range(8):
+        y = (i - 3.5) * PITCH
+        component.add_pin(str(i + 1), dx=-ROW/2, dy=y)
+        component.add_pad(str(i + 1), dx=-ROW/2, dy=y, w=0.6, h=1.5)
+        component.add_pin(str(i + 9), dx=ROW/2, dy=-y)
+        component.add_pad(str(i + 9), dx=ROW/2, dy=-y, w=0.6, h=1.5)

--- a/boardforge/footprints/sot223.py
+++ b/boardforge/footprints/sot223.py
@@ -1,0 +1,16 @@
+from ..Component import Component
+
+
+def apply(component: Component):
+    pads = [
+        ("1", -2.3, -2),
+        ("2", 0.0, -2),
+        ("3", 2.3, -2),
+        ("TAB", 0.0, 2.0),
+    ]
+    for name, dx, dy in pads:
+        component.add_pin(name, dx=dx, dy=dy)
+        if name == "TAB":
+            component.add_pad(name, dx=dx, dy=dy, w=6.0, h=3.0)
+        else:
+            component.add_pad(name, dx=dx, dy=dy, w=1.5, h=1.5)

--- a/boardforge/footprints/tactile_switch.py
+++ b/boardforge/footprints/tactile_switch.py
@@ -1,0 +1,8 @@
+from ..Component import Component
+
+
+def apply(component: Component):
+    offsets = [(-1.5, 0), (1.5, 0)]
+    for i, (dx, dy) in enumerate(offsets, start=1):
+        component.add_pin(str(i), dx=dx, dy=dy)
+        component.add_pad(str(i), dx=dx, dy=dy, w=1.2, h=1.2)

--- a/boardforge/footprints/usb_c_cutout.py
+++ b/boardforge/footprints/usb_c_cutout.py
@@ -1,0 +1,13 @@
+from ..Component import Component
+
+
+def apply(component: Component):
+    pads = [
+        ("A1", -3.5, 0),
+        ("A2", -1.2, 0),
+        ("A3", 1.2, 0),
+        ("A4", 3.5, 0),
+    ]
+    for name, dx, dy in pads:
+        component.add_pin(name, dx=dx, dy=dy)
+        component.add_pad(name, dx=dx, dy=dy, w=0.9, h=1.2)

--- a/tests/test_footprints.py
+++ b/tests/test_footprints.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from boardforge import Component
+from boardforge.footprints import get_footprint
+from boardforge.__init__ import Footprint
+
+
+@pytest.mark.parametrize("name,expected", [
+    (Footprint.C0603.value, (2, [(-0.5, 0), (0.5, 0)])),
+    (Footprint.TACTILE_SWITCH.value, (2, [(-1.5, 0), (1.5, 0)])),
+    (Footprint.HEADER_1x5.value, (5, [(0, 0), (0, 10.16)])),
+    (Footprint.SOP16.value, (16, [(-2.0, -4.445), (2.0, -4.445)])),
+    (Footprint.SOT223.value, (4, [(-2.3, -2), (0, 2)])),
+    (Footprint.USB_C_CUTOUT.value, (4, [(-3.5, 0), (3.5, 0)])),
+    (Footprint.ESP32_WROOM.value, (38, [(-9.0, -18.0), (9.0, 18.0)])),
+    ("HDMI", (23, [(-4.5, 0), (4.5, 2.4)])),
+])
+def test_footprint_pads(name, expected):
+    count, locs = expected
+    comp = Component("U1", "TEST", at=(0, 0))
+    loader = get_footprint(name)
+    loader(comp)
+    assert len(comp.pads) == count
+    # check first and last pad locations
+    assert pytest.approx(comp.pads[0].x, rel=1e-6) == locs[0][0]
+    assert pytest.approx(comp.pads[0].y, rel=1e-6) == locs[0][1]
+    assert pytest.approx(comp.pads[-1].x, rel=1e-6) == locs[1][0]
+    assert pytest.approx(comp.pads[-1].y, rel=1e-6) == locs[1][1]


### PR DESCRIPTION
## Summary
- add new `footprints/` package implementing PCB footprints
- support loading footprints in `Component`
- include footprints for HDMI connector, ESP32 module and others
- test each footprint for correct pad coordinates

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d46a5e2d48329984996f9c6d88f9c