### PR TITLE
Add castellated pad support

### DIFF
--- a/boardforge/Component.py
+++ b/boardforge/Component.py
@@ -10,6 +10,10 @@ class Pad:
         self.w = w
         self.h = h
         self.component = comp
+        # Attributes for more advanced pad types
+        self.castellated = False
+        self.plated = True
+        self.edge = None
 
 class Component:
     def __init__(self, ref, type, at, rotation=0):
@@ -20,10 +24,31 @@ class Component:
         self.pads = []
         self.pins = {}
 
-    def add_pad(self, name, dx, dy, w, h):
+    def add_pad(self, name, dx, dy, w, h, castellated=False, plated=True, edge=None):
         pad = Pad(name, self, dx, dy, w, h, self.rotation)
+        pad.castellated = castellated
+        pad.plated = plated
+        pad.edge = edge
         self.pads.append(pad)
         return pad
+
+    def add_castellated_pad(self, name, board, edge, offset, diameter=1.0, plated=True):
+        """Place a pad centred on the given board edge."""
+        if edge not in {"top", "bottom", "left", "right"}:
+            raise ValueError("edge must be one of 'top', 'bottom', 'left', 'right'")
+
+        if edge in {"top", "bottom"}:
+            x = offset
+            y = board.height if edge == "top" else 0
+        else:
+            x = board.width if edge == "right" else 0
+            y = offset
+
+        r = math.radians(self.rotation)
+        dx = (x - self.at[0]) * math.cos(r) + (y - self.at[1]) * math.sin(r)
+        dy = -(x - self.at[0]) * math.sin(r) + (y - self.at[1]) * math.cos(r)
+
+        return self.add_pad(name, dx, dy, diameter, diameter, castellated=True, plated=plated, edge=edge)
 
     def add_pin(self, name, dx, dy):
         pin = Pin(name, self.at, dx, dy, self.rotation)

--- a/tests/test_castellated.py
+++ b/tests/test_castellated.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+from io import BytesIO
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from boardforge import PCB, Layer
+
+
+def test_castellated_pad_preview(tmp_path):
+    board = PCB(width=6, height=4)
+    board.set_layer_stack([
+        Layer.TOP_COPPER.value,
+        Layer.BOTTOM_COPPER.value,
+        Layer.TOP_SILK.value,
+        Layer.BOTTOM_SILK.value,
+    ])
+    comp = board.add_component("EDGE", ref="J1", at=(0, 0))
+    for i in range(3):
+        comp.add_castellated_pad(f"P{i}", board, edge="bottom", offset=1 + 2 * i, diameter=1.0)
+
+    board.save_svg_previews(tmp_path)
+    svg_path = tmp_path / "preview_top.svg"
+    png_path = tmp_path / "preview_top.png"
+
+    svg_data = svg_path.read_text()
+    assert svg_data.count("fill=\"#ffc100\"") >= 3
+
+    import re
+    m = re.search(r'<polygon points="([^"]+)" fill="\#5d2292"', svg_data)
+    assert m
+    pts = m.group(1).split()
+    assert len(pts) > 20
+
+    with Image.open(png_path) as img:
+        px = int(1 * 10)
+        assert img.getpixel((px, 0))[:3] == (51, 51, 51)
+        assert img.getpixel((px, 1)) == (255, 193, 0, 255)


### PR DESCRIPTION
## Summary
- extend `Component.add_pad` to track castellated pads
- add `Component.add_castellated_pad` helper
- carve castellated cut-outs in `Board.save_svg_previews`
- render semicircular pads and rings
- test castellated pad preview rendering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f0436e5588329a4ff2e428781b170