### PR TITLE
Add Dazzler logos to board preview

### DIFF
--- a/examples/dazzler.py
+++ b/examples/dazzler.py
@@ -1,10 +1,11 @@
 from pathlib import Path
-from PIL import Image, ImageDraw
 from boardforge import PCB, Layer, Footprint
 
 BASE_DIR = Path(__file__).resolve().parent
 FONT_PATH = BASE_DIR.parent / "fonts" / "RobotoMono.ttf"
-GRAPHIC_PATH = BASE_DIR.parent / "graphics" / "torch.svg"
+TORCH_PATH = BASE_DIR.parent / "graphics" / "torch.svg"
+GD3X_PATH = BASE_DIR.parent / "graphics" / "gd3x.svg"
+OSHW_PATH = BASE_DIR.parent / "graphics" / "oshw.svg"
 OUTPUT_DIR = BASE_DIR.parent / "output"
 
 
@@ -114,14 +115,27 @@ def build_board():
     board.fill([(5, 5), (w-5, 5), (w-5, h-5), (5, h-5)], layer=Layer.BOTTOM_COPPER.value)
 
     # Silkscreen text and graphics
-    board.annotate(5, 38, "Dazzler", size=1.5, layer=Layer.TOP_SILK)
-    board.add_text_ttf("Mega Example", font_path=str(FONT_PATH), at=(10, h/2), size=1.5, layer=Layer.TOP_SILK.value)
-    if GRAPHIC_PATH.exists():
-        board.add_svg_graphic(str(GRAPHIC_PATH), layer=Layer.TOP_SILK.value, scale=0.5, at=(2, 2))
-    img = Image.new("RGBA", (3, 3), (0, 0, 0, 0))
-    draw = ImageDraw.Draw(img)
-    draw.rectangle([0, 0, 2, 2], fill=(255, 0, 0, 255))
-    board.logo(45, 35, img, scale=0.5, layer=Layer.TOP_SILK)
+    board.annotate(w / 2 - 8, h - 4, "Dazzler", size=1.5, layer=Layer.TOP_SILK)
+    board.add_text_ttf(
+        "Mega Example",
+        font_path=str(FONT_PATH),
+        at=(w / 2 - 10, h / 2 - 2),
+        size=1.5,
+        layer=Layer.TOP_SILK.value,
+    )
+
+    if TORCH_PATH.exists():
+        board.add_svg_graphic(
+            str(TORCH_PATH), layer=Layer.TOP_SILK.value, scale=0.5, at=(2, 2)
+        )
+    if GD3X_PATH.exists():
+        board.add_svg_graphic(
+            str(GD3X_PATH), layer=Layer.TOP_SILK.value, scale=0.6, at=(32, 4)
+        )
+    if OSHW_PATH.exists():
+        board.add_svg_graphic(
+            str(OSHW_PATH), layer=Layer.TOP_SILK.value, scale=0.5, at=(42, 32)
+        )
 
     # Skip DRC in this example to focus on footprint placement
     board.design_rule_check = lambda *a, **k: []

--- a/graphics/gd3x.svg
+++ b/graphics/gd3x.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="10">
+  <text x="0" y="8" font-size="8" font-family="Arial" fill="white">GD3X</text>
+</svg>

--- a/graphics/oshw.svg
+++ b/graphics/oshw.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12">
+  <polygon points="6,0 7,1 9,1 10,0 11,1 11,3 12,4 11,6 12,7 11,9 11,11 10,12 9,11 7,11 6,12 5,11 3,11 2,12 1,11 1,9 0,8 1,6 0,4 1,3 1,1 2,0 3,1 5,1" fill="white"/>
+  <circle cx="6" cy="6" r="2" fill="black"/>
+</svg>

--- a/tests/test_dazzler.py
+++ b/tests/test_dazzler.py
@@ -26,3 +26,8 @@ def test_dazzler_board(tmp_path):
             "preview_top.png",
             "preview_bottom.png",
         }.issubset(names)
+
+    with open(tmp_path / "preview_top.svg", "r", encoding="utf-8") as f:
+        data = f.read()
+        assert "GD3X" in data
+        assert "polygon" in data and "fill=\"white\"" in data


### PR DESCRIPTION
## Summary
- include `gd3x.svg` and `oshw.svg`
- add new logo paths in `build_board()`
- embed the logos in the generated preview
- remove the placeholder bitmap graphic and tweak text
- test that previews contain the SVG logo elements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f0a6addf48329a73e1da4448196e9