### PR TITLE
docs: clarify test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,17 @@ Each script checks for Python 3 and then installs `requirements.txt`.
 
 ## Running the tests
 
-Install the dependencies before running the test suite:
+Install the packages listed in `requirements.txt` before executing the test
+suite:
 
 ```bash
 pip install -r requirements.txt
 pytest
 ```
-An optional `requirements-dev.txt` pins the package versions used in CI.
+
+The example scripts require additional libraries such as **Pillow**,
+**CairoSVG** and **Shapely**, which are included in the dependency file. An
+optional `requirements-dev.txt` pins the package versions used in CI.
 
 ## License
 


### PR DESCRIPTION
## Summary
- update README with explicit instructions for running tests
- mention Pillow, CairoSVG and Shapely in examples

## Testing
- `pytest -q`
- `ruff check boardforge tests` *(fails: multiple lint errors)*
- `mypy boardforge` *(fails: duplicate module path)*
- `black --check boardforge` *(fails: would reformat files)*

------
https://chatgpt.com/codex/tasks/task_e_687f141cca108329a8b3b20e7fe98dd1